### PR TITLE
fix: add missing packages to pre-release mode configuration

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -3,7 +3,9 @@
   "tag": "alpha",
   "initialVersions": {
     "@api-extractor-tools/change-detector": "0.0.1",
-    "@api-extractor-tools/module-declaration-merger": "0.0.1"
+    "@api-extractor-tools/module-declaration-merger": "0.0.1",
+    "@api-extractor-tools/changeset-change-detector": "0.0.1",
+    "@api-extractor-tools/change-detector-semantic-release-plugin": "0.0.1"
   },
   "changesets": []
 }


### PR DESCRIPTION
## Summary

Fixes the release workflow failure on main by adding the two missing packages to the changesets pre-release mode configuration.

## Problem

The release workflow was failing with the "Create Release Pull Request" step because the `.changeset/pre.json` file was missing entries for the two new packages that were recently added:
- `@api-extractor-tools/changeset-change-detector`
- `@api-extractor-tools/change-detector-semantic-release-plugin`

When `changeset version` runs in pre-release mode, it needs to know about all packages in the monorepo. Without these entries, the command fails.

## Changes

Updated `.changeset/pre.json` to include `initialVersions` entries for both new packages at version `0.0.1`.

## Testing

After merging this PR, the release workflow should successfully run and create a version bump PR with the pending changesets.