### PR TITLE
test: add CLI integration tests for change-detector and changeset-change-detector

### DIFF
--- a/tools/change-detector/test/cli.test.ts
+++ b/tools/change-detector/test/cli.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { Project } from 'fixturify-project'
+import * as path from 'path'
+import { execSync } from 'child_process'
+
+/**
+ * Runs the CLI and returns its output.
+ * Uses the compiled CLI from dist.
+ */
+function runCli(
+  args: string[],
+  options: { cwd?: string; env?: Record<string, string> } = {},
+): { stdout: string; stderr: string; exitCode: number } {
+  const cliPath = path.join(__dirname, '../dist/cli.js')
+  const cmd = `node ${cliPath} ${args.join(' ')}`
+
+  try {
+    const stdout = execSync(cmd, {
+      cwd: options.cwd,
+      encoding: 'utf-8',
+      env: { ...process.env, ...options.env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    return { stdout, stderr: '', exitCode: 0 }
+  } catch (error) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const e = error as any
+    return {
+      stdout: e.stdout?.toString() || '',
+      stderr: e.stderr?.toString() || '',
+      exitCode: e.status ?? 1,
+    }
+  }
+}
+
+describe('CLI', () => {
+  let project: Project
+
+  beforeEach(() => {
+    project = new Project('test-pkg')
+  })
+
+  afterEach(async () => {
+    await project.dispose()
+  })
+
+  describe('argument parsing', () => {
+    it('shows help with --help flag', () => {
+      const result = runCli(['--help'])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('change-detector')
+      expect(result.stdout).toContain('USAGE')
+      expect(result.stdout).toContain('OPTIONS')
+      expect(result.stdout).toContain('ARGUMENTS')
+    })
+
+    it('shows help with -h flag', () => {
+      const result = runCli(['-h'])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('change-detector')
+    })
+
+    it('shows version with --version flag', () => {
+      const result = runCli(['--version'])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('change-detector')
+      expect(result.stdout).toMatch(/v?\d+\.\d+\.\d+/)
+    })
+
+    it('shows version with -V flag', () => {
+      const result = runCli(['-V'])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toMatch(/v?\d+\.\d+\.\d+/)
+    })
+  })
+
+  describe('error handling', () => {
+    it('fails when no files are provided', () => {
+      const result = runCli([])
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain(
+        'Both old and new declaration files are required',
+      )
+    })
+
+    it('fails when only one file is provided', async () => {
+      project.files = {
+        'old.d.ts': 'export declare const foo: string;',
+      }
+      await project.write()
+
+      const result = runCli([path.join(project.baseDir, 'old.d.ts')])
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain(
+        'Both old and new declaration files are required',
+      )
+    })
+
+    it('handles missing old file by treating as empty', async () => {
+      project.files = {
+        'new.d.ts': 'export declare const foo: string;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--json',
+      ])
+
+      // CLI treats missing files as empty - detects all symbols as additions
+      expect(result.exitCode).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      expect(parsed.releaseType).toBe('minor')
+    })
+
+    it('handles missing new file by treating as empty', async () => {
+      project.files = {
+        'old.d.ts': 'export declare const foo: string;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--json',
+      ])
+
+      // CLI treats missing files as empty - detects all symbols as removals
+      expect(result.exitCode).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      expect(parsed.releaseType).toBe('major')
+    })
+  })
+
+  describe('output formats', () => {
+    it('outputs text format by default', async () => {
+      project.files = {
+        'old.d.ts': 'export declare const foo: string;',
+        'new.d.ts': 'export declare const foo: string;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+      ])
+
+      expect(result.exitCode).toBe(0)
+      // Default text output should not be JSON
+      expect(() => JSON.parse(result.stdout)).toThrow()
+    })
+
+    it('outputs JSON with --json flag', async () => {
+      project.files = {
+        'old.d.ts': 'export declare const foo: string;',
+        'new.d.ts': 'export declare const foo: string;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--json',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      expect(parsed).toHaveProperty('releaseType')
+      expect(parsed).toHaveProperty('changes')
+    })
+
+    it('outputs markdown with --markdown flag', async () => {
+      project.files = {
+        'old.d.ts': 'export declare const foo: string;',
+        'new.d.ts': 'export declare const foo: string;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--markdown',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      // Markdown output should contain markdown-style headers
+      expect(result.stdout).toContain('#')
+    })
+
+    it('outputs markdown with --md flag', async () => {
+      project.files = {
+        'old.d.ts': 'export declare const foo: string;',
+        'new.d.ts': 'export declare const foo: string;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--md',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('#')
+    })
+  })
+
+  describe('change detection', () => {
+    it('detects no changes between identical files', async () => {
+      project.files = {
+        'old.d.ts': 'export declare const foo: string;',
+        'new.d.ts': 'export declare const foo: string;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--json',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      expect(parsed.releaseType).toBe('none')
+      expect(parsed.changes.breaking).toHaveLength(0)
+      expect(parsed.changes.nonBreaking).toHaveLength(0)
+    })
+
+    it('detects additions as minor changes', async () => {
+      project.files = {
+        'old.d.ts': 'export declare const foo: string;',
+        'new.d.ts': `export declare const foo: string;
+export declare const bar: number;`,
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--json',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      expect(parsed.releaseType).toBe('minor')
+      expect(parsed.changes.nonBreaking.length).toBeGreaterThan(0)
+    })
+
+    it('detects removals as major changes', async () => {
+      project.files = {
+        'old.d.ts': `export declare const foo: string;
+export declare const bar: number;`,
+        'new.d.ts': 'export declare const foo: string;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--json',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      expect(parsed.releaseType).toBe('major')
+    })
+
+    it('detects type changes as breaking', async () => {
+      project.files = {
+        'old.d.ts': 'export declare const foo: string;',
+        'new.d.ts': 'export declare const foo: number;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--json',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      expect(parsed.releaseType).toBe('major')
+    })
+  })
+
+  describe('exit codes', () => {
+    it('returns 0 on successful comparison', async () => {
+      project.files = {
+        'old.d.ts': 'export declare const foo: string;',
+        'new.d.ts': 'export declare const foo: string;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+      ])
+
+      expect(result.exitCode).toBe(0)
+    })
+
+    it('returns 1 when missing required arguments', () => {
+      const result = runCli([])
+
+      expect(result.exitCode).toBe(1)
+    })
+  })
+
+  describe('complex scenarios', () => {
+    it('handles interface changes', async () => {
+      project.files = {
+        'old.d.ts': `export interface User {
+  id: string;
+  name: string;
+}`,
+        'new.d.ts': `export interface User {
+  id: string;
+  name: string;
+  email: string;
+}`,
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--json',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      // Adding properties to interface is detected as a change
+      const totalChanges =
+        parsed.changes.breaking.length + parsed.changes.nonBreaking.length
+      expect(totalChanges).toBeGreaterThan(0)
+    })
+
+    it('handles function signature changes', async () => {
+      project.files = {
+        'old.d.ts': 'export declare function greet(name: string): string;',
+        'new.d.ts':
+          'export declare function greet(name: string, greeting?: string): string;',
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--json',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      // Adding optional parameter should be minor
+      expect(['minor', 'patch']).toContain(parsed.releaseType)
+    })
+
+    it('handles class changes', async () => {
+      project.files = {
+        'old.d.ts': `export declare class MyClass {
+  constructor();
+  getValue(): string;
+}`,
+        'new.d.ts': `export declare class MyClass {
+  constructor();
+  getValue(): string;
+  setValue(value: string): void;
+}`,
+      }
+      await project.write()
+
+      const result = runCli([
+        path.join(project.baseDir, 'old.d.ts'),
+        path.join(project.baseDir, 'new.d.ts'),
+        '--json',
+      ])
+
+      expect(result.exitCode).toBe(0)
+      const parsed = JSON.parse(result.stdout)
+      // Adding a method to a class is considered major (changes class shape)
+      expect(parsed.releaseType).toBe('major')
+    })
+  })
+})

--- a/tools/changeset-change-detector/test/cli.test.ts
+++ b/tools/changeset-change-detector/test/cli.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { Project } from 'fixturify-project'
+import * as path from 'path'
+import { execSync } from 'child_process'
+
+/**
+ * Runs the CLI and returns its output.
+ * Uses the compiled CLI from dist.
+ */
+function runCli(
+  args: string[],
+  options: { cwd?: string; env?: Record<string, string> } = {},
+): { stdout: string; stderr: string; exitCode: number } {
+  const cliPath = path.join(__dirname, '../dist/cli.js')
+  const cmd = `node ${cliPath} ${args.join(' ')}`
+
+  try {
+    const stdout = execSync(cmd, {
+      cwd: options.cwd,
+      encoding: 'utf-8',
+      env: { ...process.env, ...options.env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    return { stdout, stderr: '', exitCode: 0 }
+  } catch (error) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const e = error as any
+    return {
+      stdout: e.stdout?.toString() || '',
+      stderr: e.stderr?.toString() || '',
+      exitCode: e.status ?? 1,
+    }
+  }
+}
+
+describe('CLI', () => {
+  let project: Project
+
+  beforeEach(() => {
+    project = new Project('test-workspace')
+  })
+
+  afterEach(async () => {
+    await project.dispose()
+  })
+
+  describe('argument parsing', () => {
+    it('shows help with --help flag', () => {
+      const result = runCli(['--help'])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('changeset-change-detector')
+      expect(result.stdout).toContain('USAGE')
+      expect(result.stdout).toContain('COMMANDS')
+      expect(result.stdout).toContain('OPTIONS')
+      expect(result.stdout).toContain('EXAMPLES')
+    })
+
+    it('shows help with -h flag', () => {
+      const result = runCli(['-h'])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('changeset-change-detector')
+    })
+
+    it('shows help with help command', () => {
+      const result = runCli(['help'])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('changeset-change-detector')
+      expect(result.stdout).toContain('USAGE')
+    })
+
+    it('shows version with --version flag', () => {
+      const result = runCli(['--version'])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain('changeset-change-detector')
+      expect(result.stdout).toMatch(/v?\d+\.\d+\.\d+/)
+    })
+
+    it('shows version with -V flag', () => {
+      const result = runCli(['-V'])
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toMatch(/v?\d+\.\d+\.\d+/)
+    })
+  })
+
+  describe('command handling', () => {
+    it('fails when no command is specified', () => {
+      const result = runCli([])
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('No command specified')
+      expect(result.stderr).toContain('changeset-change-detector --help')
+    })
+
+    it('fails for unknown commands', () => {
+      const result = runCli(['unknown-command'])
+
+      expect(result.exitCode).toBe(1)
+      expect(result.stderr).toContain('No command specified')
+    })
+  })
+
+  describe('generate command', () => {
+    it('accepts the generate command', async () => {
+      // Create a minimal workspace without .changeset - should fail gracefully
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['generate'], { cwd: project.baseDir })
+
+      // Should attempt analysis (may fail due to missing git/config, but command is recognized)
+      expect(result.stdout).toContain('Analyzing API changes')
+      expect(result.exitCode).toBe(1) // Fails because workspace isn't properly set up
+    })
+
+    it('accepts --yes flag with generate', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['generate', '--yes'], { cwd: project.baseDir })
+
+      // --yes should be accepted (even if generate fails)
+      expect(result.stdout).toContain('Analyzing')
+    })
+
+    it('accepts -y flag with generate', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['generate', '-y'], { cwd: project.baseDir })
+
+      expect(result.stdout).toContain('Analyzing')
+    })
+
+    it('accepts --base flag with generate', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['generate', '--base', 'main'], {
+        cwd: project.baseDir,
+      })
+
+      // Should attempt to analyze with base ref
+      expect(result.stdout).toContain('Analyzing')
+    })
+
+    it('accepts -b flag with generate', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['generate', '-b', 'main'], { cwd: project.baseDir })
+
+      expect(result.stdout).toContain('Analyzing')
+    })
+
+    it('accepts --summary flag with generate', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['generate', '--summary', 'Custom summary text'], {
+        cwd: project.baseDir,
+      })
+
+      expect(result.stdout).toContain('Analyzing')
+    })
+
+    it('accepts -s flag with generate', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['generate', '-s', 'Custom summary'], {
+        cwd: project.baseDir,
+      })
+
+      expect(result.stdout).toContain('Analyzing')
+    })
+  })
+
+  describe('validate command', () => {
+    it('accepts the validate command', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['validate'], { cwd: project.baseDir })
+
+      // Should attempt validation
+      expect(result.stdout).toContain('Validating changesets')
+    })
+
+    it('accepts --strict flag with validate', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['validate', '--strict'], { cwd: project.baseDir })
+
+      expect(result.stdout).toContain('Validating')
+    })
+
+    it('accepts --base flag with validate', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['validate', '--base', 'main'], {
+        cwd: project.baseDir,
+      })
+
+      expect(result.stdout).toContain('Validating')
+    })
+
+    it('accepts -b flag with validate', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['validate', '-b', 'main'], { cwd: project.baseDir })
+
+      expect(result.stdout).toContain('Validating')
+    })
+  })
+
+  describe('combined flags', () => {
+    it('supports multiple flags with generate', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(
+        ['generate', '--yes', '--base', 'main', '--summary', 'Test'],
+        { cwd: project.baseDir },
+      )
+
+      expect(result.stdout).toContain('Analyzing')
+    })
+
+    it('supports short flags combined', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: 'test-workspace',
+          private: true,
+        }),
+      }
+      await project.write()
+
+      const result = runCli(['generate', '-y', '-b', 'main', '-s', 'Test'], {
+        cwd: project.baseDir,
+      })
+
+      expect(result.stdout).toContain('Analyzing')
+    })
+  })
+
+  describe('help information', () => {
+    it('documents all commands in help', () => {
+      const result = runCli(['--help'])
+
+      expect(result.stdout).toContain('generate')
+      expect(result.stdout).toContain('validate')
+    })
+
+    it('documents all options in help', () => {
+      const result = runCli(['--help'])
+
+      expect(result.stdout).toContain('--base')
+      expect(result.stdout).toContain('-b')
+      expect(result.stdout).toContain('--yes')
+      expect(result.stdout).toContain('-y')
+      expect(result.stdout).toContain('--strict')
+      expect(result.stdout).toContain('--summary')
+      expect(result.stdout).toContain('-s')
+      expect(result.stdout).toContain('--help')
+      expect(result.stdout).toContain('-h')
+      expect(result.stdout).toContain('--version')
+      expect(result.stdout).toContain('-V')
+    })
+
+    it('provides usage examples in help', () => {
+      const result = runCli(['--help'])
+
+      expect(result.stdout).toContain('EXAMPLES')
+      expect(result.stdout).toContain('changeset-change-detector generate')
+      expect(result.stdout).toContain('changeset-change-detector validate')
+    })
+
+    it('documents baseline detection in help', () => {
+      const result = runCli(['--help'])
+
+      expect(result.stdout).toContain('BASELINE DETECTION')
+    })
+  })
+
+  describe('exit codes', () => {
+    it('returns 0 on successful help', () => {
+      const result = runCli(['--help'])
+
+      expect(result.exitCode).toBe(0)
+    })
+
+    it('returns 0 on successful version', () => {
+      const result = runCli(['--version'])
+
+      expect(result.exitCode).toBe(0)
+    })
+
+    it('returns 1 when no command specified', () => {
+      const result = runCli([])
+
+      expect(result.exitCode).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add comprehensive CLI integration tests for `@change-detector` and `@changeset-change-detector` packages
- Both packages now have tests that invoke the actual CLI executables via `node dist/cli.js`
- The `@module-declaration-merger` package already had CLI tests

## Test Coverage

| Package | CLI Tests | Coverage |
|---------|-----------|----------|
| `@change-detector` | 21 tests | arg parsing, output formats (text/JSON/markdown), change detection, exit codes |
| `@changeset-change-detector` | 27 tests | generate/validate commands, flag combinations, help docs, exit codes |
| `@module-declaration-merger` | 22 tests (existing) | full coverage |

## Test Plan

- [x] All 336 tests pass across all 4 packages
- [x] CLI tests invoke actual compiled executables
- [x] Tests cover happy paths and error cases