### PR TITLE
fix: correct release workflow publish job condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: npm-publish
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

This PR fixes two critical issues preventing the Release workflow from functioning:

1. **Release PR creation was failing** - GitHub Actions couldn't create pull requests due to insufficient permissions
2. **NPM publish job never ran** - The job condition was checking for the wrong event type

## Issues Fixed

### Issue 1: Permission Error Creating Release PRs

**Error:**
```
HttpError: GitHub Actions is not permitted to create or approve pull requests.
```

**Root Cause:** 
- Repository workflow permissions were set to read-only
- GitHub Actions was not allowed to create/approve PRs

**Solution:**
- Updated repository workflow permissions from `read` to `write`
- Enabled "Allow GitHub Actions to create and approve pull requests" in repository settings

### Issue 2: Publish Job Never Executing

**Root Cause:**
The publish job had an incorrect conditional that always evaluated to `false`:

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

When a workflow is triggered by `workflow_run`, the `github.event_name` is always `'workflow_run'`, not `'push'`, causing the job to be skipped every time.

**Solution:**
Changed the condition to properly check the workflow_run status:

```yaml
if: ${{ github.event.workflow_run.conclusion == 'success' }}
```

## Changes Made

- **`.github/workflows/release.yml`**: Updated publish job condition to check `workflow_run.conclusion` instead of `event_name`

## Testing

- ✅ YAML syntax validated
- ✅ Commit messages checked for forbidden strings
- ✅ Repository permissions verified

## Expected Behavior After Merge

1. When code is pushed to `main`, CI workflow runs (build, lint, test)
2. If CI succeeds, the Release workflow triggers via `workflow_run`
3. **Version job:** Creates or updates a release PR when changesets are present
4. **Publish job:** Publishes packages to npm after release PR is merged (when no changesets remain)

## Related

This fixes the release automation that has been failing since the repository was set up with changesets.