### PR TITLE
feat(demo-site): convert theme toggle to dropdown

### DIFF
--- a/.changeset/theme-dropdown.md
+++ b/.changeset/theme-dropdown.md
@@ -1,0 +1,7 @@
+---
+'@api-extractor-tools/demo-site': patch
+---
+
+Convert theme toggle button to dropdown for better UX
+
+The theme selector is now a dropdown instead of a 3-state cycle button, making it immediately clear that there are three theme options available (Light, Dark, and Auto). This improves discoverability and makes the current selection more obvious to users.

--- a/tools/demo-site/src/App.tsx
+++ b/tools/demo-site/src/App.tsx
@@ -80,19 +80,9 @@ function App() {
     localStorage.setItem('theme', themePreference)
   }, [resolvedTheme, themePreference])
 
-  const toggleTheme = useCallback(() => {
-    setThemePreference((prev) => {
-      if (prev === 'light') return 'dark'
-      if (prev === 'dark') return 'auto'
-      return 'light'
-    })
+  const handleThemeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    setThemePreference(e.target.value as ThemePreference)
   }, [])
-
-  const getThemeButtonText = () => {
-    if (themePreference === 'light') return 'Dark'
-    if (themePreference === 'dark') return 'Auto'
-    return `Light` // Auto mode
-  }
 
   // Auto-analyze with 100ms debounce
   useEffect(() => {
@@ -224,14 +214,16 @@ ${report ? formatReportAsText(report) : 'No analysis available'}
               </option>
             ))}
           </select>
-          <button 
-            className="theme-toggle" 
-            onClick={toggleTheme} 
-            aria-label={themePreference === 'auto' ? `Theme: Auto (currently ${resolvedTheme}). Click to switch to light mode` : `Theme: ${themePreference}. Click to switch to ${getThemeButtonText().toLowerCase()} mode`}
-            title={themePreference === 'auto' ? `Auto (currently ${resolvedTheme})` : `Switch to ${getThemeButtonText()} mode`}
+          <select
+            className="theme-toggle"
+            value={themePreference}
+            onChange={handleThemeChange}
+            aria-label="Theme preference"
           >
-            {getThemeButtonText()}
-          </button>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+            <option value="auto">Auto (System)</option>
+          </select>
           <button className="copy-button" onClick={handleCopyForLLM}>
             {copyFeedback ?? 'Copy for LLM'}
           </button>

--- a/tools/demo-site/src/index.css
+++ b/tools/demo-site/src/index.css
@@ -93,7 +93,8 @@ body {
   align-items: center;
 }
 
-.example-select {
+.example-select,
+.theme-toggle {
   padding: 0.5rem 1rem;
   border-radius: 4px;
   border: 1px solid var(--color-border);
@@ -101,15 +102,22 @@ body {
   color: var(--color-text);
   font-size: 0.875rem;
   cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
 }
 
-.example-select:focus {
+.example-select:focus,
+.theme-toggle:focus {
   outline: none;
   border-color: var(--color-primary);
 }
 
+.example-select:hover,
+.theme-toggle:hover {
+  background-color: var(--color-surface);
+  border-color: var(--color-primary);
+}
+
 .copy-button,
-.theme-toggle,
 .report-issue-button {
   padding: 0.5rem 1rem;
   border-radius: 4px;
@@ -123,21 +131,18 @@ body {
 }
 
 .copy-button:hover,
-.theme-toggle:hover,
 .report-issue-button:hover:not(:disabled) {
   background-color: var(--color-surface);
   border-color: var(--color-primary);
 }
 
 .copy-button:focus,
-.theme-toggle:focus,
 .report-issue-button:focus {
   outline: none;
   border-color: var(--color-primary);
 }
 
 .copy-button:active,
-.theme-toggle:active,
 .report-issue-button:active:not(:disabled) {
   background-color: var(--color-primary);
   color: var(--color-bg);


### PR DESCRIPTION
## Summary

This PR improves the theme selector UX in the demo site by converting the 3-state cycle button into a dropdown menu. This makes it immediately clear to users that there are three distinct theme options available (Light, Dark, and Auto) rather than requiring them to click through multiple times to discover all states.

## Changes

### UI/UX Improvements
- **Replaced button with dropdown**: The theme selector is now a `<select>` element with three explicit options instead of a button that cycles through states
- **Better discoverability**: Users can now see all available theme options at once
- **Clearer current selection**: The dropdown shows exactly which theme is currently active
- **Consistent styling**: The theme dropdown now shares the same styling patterns as the example selector

### Code Changes
- **App.tsx**:
  - Replaced `toggleTheme()` callback with `handleThemeChange()` for direct theme selection
  - Removed `getThemeButtonText()` helper function (no longer needed)
  - Changed theme toggle from button to select element with explicit options: "Light", "Dark", "Auto (System)"
  
- **index.css**:
  - Consolidated CSS styling between `.example-select` and `.theme-toggle`
  - Removed button-specific styles from theme toggle (`:active` states)
  - Added consistent hover and focus states for both select elements

- **App.test.tsx**:
  - Updated all theme-related tests to work with dropdown selection instead of button clicks
  - Changed from "click to cycle through states" to "select specific option" semantics
  - Updated tests to distinguish between multiple comboboxes (example selector vs theme selector)
  - All 72 tests pass

## Testing

- ✅ All tests pass (72/72)
- ✅ Lint checks pass
- ✅ Build passes
- ✅ Knip checks pass
- ✅ Manual testing: Theme dropdown works correctly in both light and dark modes, and properly respects system preferences in Auto mode

## Changeset

A changeset has been included for a patch version bump of `@api-extractor-tools/demo-site`.