### PR TITLE
test: add comprehensive test coverage for core modules

### DIFF
--- a/.changeset/add-test-coverage-and-validation.md
+++ b/.changeset/add-test-coverage-and-validation.md
@@ -1,0 +1,5 @@
+---
+'@api-extractor-tools/change-detector-semantic-release-plugin': patch
+---
+
+Add validation error when package.json has both `types` and `typings` fields. Using both is redundant and confusing - only `types` should be used (the `typings` field is deprecated).

--- a/tools/change-detector-core/test/comparator.test.ts
+++ b/tools/change-detector-core/test/comparator.test.ts
@@ -1,0 +1,504 @@
+import { describe, it, expect } from 'vitest'
+import * as ts from 'typescript'
+import {
+  compareDeclarationStrings,
+  compareDeclarationResults,
+} from '../src/comparator'
+import { parseDeclarationStringWithTypes } from '../src/parser-core'
+
+/**
+ * Helper to compare two declaration strings directly using the comparator module.
+ */
+function compareStrings(oldContent: string, newContent: string) {
+  return compareDeclarationStrings(oldContent, newContent, ts)
+}
+
+describe('compareDeclarationStrings', () => {
+  describe('basic comparisons', () => {
+    it('detects no changes for identical content', () => {
+      const content = 'export declare function foo(): void;'
+      const result = compareStrings(content, content)
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.changes).toHaveLength(1)
+      expect(result.changes[0]?.category).toBe('signature-identical')
+      expect(result.changes[0]?.releaseType).toBe('none')
+    })
+
+    it('detects symbol addition', () => {
+      const oldContent = 'export declare function foo(): void;'
+      const newContent = `
+        export declare function foo(): void;
+        export declare function bar(): void;
+      `
+      const result = compareStrings(oldContent, newContent)
+
+      const added = result.changes.find((c) => c.category === 'symbol-added')
+      expect(added).toBeDefined()
+      expect(added?.symbolName).toBe('bar')
+      expect(added?.releaseType).toBe('minor')
+    })
+
+    it('detects symbol removal', () => {
+      const oldContent = `
+        export declare function foo(): void;
+        export declare function bar(): void;
+      `
+      const newContent = 'export declare function foo(): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const removed = result.changes.find(
+        (c) => c.category === 'symbol-removed',
+      )
+      expect(removed).toBeDefined()
+      expect(removed?.symbolName).toBe('bar')
+      expect(removed?.releaseType).toBe('major')
+    })
+
+    it('handles empty old content', () => {
+      const result = compareStrings('', 'export declare function foo(): void;')
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.changes).toHaveLength(1)
+      expect(result.changes[0]?.category).toBe('symbol-added')
+    })
+
+    it('handles empty new content', () => {
+      const result = compareStrings('export declare function foo(): void;', '')
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.changes).toHaveLength(1)
+      expect(result.changes[0]?.category).toBe('symbol-removed')
+    })
+
+    it('handles both empty', () => {
+      const result = compareStrings('', '')
+
+      expect(result.errors).toHaveLength(0)
+      expect(result.changes).toHaveLength(0)
+    })
+  })
+
+  describe('parameter changes', () => {
+    it('detects added required parameter as major', () => {
+      const oldContent = 'export declare function greet(name: string): void;'
+      const newContent =
+        'export declare function greet(name: string, age: number): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const greet = result.changes.find((c) => c.symbolName === 'greet')
+      expect(greet?.category).toBe('param-added-required')
+      expect(greet?.releaseType).toBe('major')
+    })
+
+    it('detects added optional parameter as minor', () => {
+      const oldContent = 'export declare function greet(name: string): void;'
+      const newContent =
+        'export declare function greet(name: string, age?: number): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const greet = result.changes.find((c) => c.symbolName === 'greet')
+      expect(greet?.category).toBe('param-added-optional')
+      expect(greet?.releaseType).toBe('minor')
+    })
+
+    it('detects removed parameter as major', () => {
+      const oldContent =
+        'export declare function greet(name: string, age: number): void;'
+      const newContent = 'export declare function greet(name: string): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const greet = result.changes.find((c) => c.symbolName === 'greet')
+      expect(greet?.category).toBe('param-removed')
+      expect(greet?.releaseType).toBe('major')
+    })
+
+    it('treats rest parameter addition as minor', () => {
+      const oldContent = 'export declare function log(msg: string): void;'
+      const newContent =
+        'export declare function log(msg: string, ...args: unknown[]): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const log = result.changes.find((c) => c.symbolName === 'log')
+      expect(log?.category).toBe('param-added-optional')
+      expect(log?.releaseType).toBe('minor')
+    })
+
+    it('detects parameter becoming optional as minor (type widening)', () => {
+      const oldContent = 'export declare function greet(name: string): void;'
+      const newContent = 'export declare function greet(name?: string): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const greet = result.changes.find((c) => c.symbolName === 'greet')
+      expect(greet?.category).toBe('type-widened')
+      expect(greet?.releaseType).toBe('minor')
+    })
+
+    it('detects parameter becoming required as major (type narrowing)', () => {
+      const oldContent = 'export declare function greet(name?: string): void;'
+      const newContent = 'export declare function greet(name: string): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const greet = result.changes.find((c) => c.symbolName === 'greet')
+      expect(greet?.category).toBe('type-narrowed')
+      expect(greet?.releaseType).toBe('major')
+    })
+
+    it('detects parameter type change as major', () => {
+      const oldContent = 'export declare function greet(name: string): void;'
+      const newContent = 'export declare function greet(name: number): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const greet = result.changes.find((c) => c.symbolName === 'greet')
+      expect(greet?.releaseType).toBe('major')
+    })
+  })
+
+  describe('return type changes', () => {
+    it('detects return type change as major', () => {
+      const oldContent = 'export declare function getValue(): string;'
+      const newContent = 'export declare function getValue(): number;'
+      const result = compareStrings(oldContent, newContent)
+
+      const getValue = result.changes.find((c) => c.symbolName === 'getValue')
+      expect(getValue?.category).toBe('return-type-changed')
+      expect(getValue?.releaseType).toBe('major')
+    })
+
+    it('detects return type widening (void to any) as major', () => {
+      const oldContent = 'export declare function getValue(): void;'
+      const newContent = 'export declare function getValue(): any;'
+      const result = compareStrings(oldContent, newContent)
+
+      const getValue = result.changes.find((c) => c.symbolName === 'getValue')
+      expect(getValue?.category).toBe('return-type-changed')
+      expect(getValue?.releaseType).toBe('major')
+    })
+  })
+
+  describe('optional marker stripping (internal logic)', () => {
+    // Tests that verify the stripTopLevelParamOptionalMarkers logic works correctly
+    // by testing through the public API
+
+    it('correctly handles optional markers at top level', () => {
+      const oldContent = 'export declare function fn(arg0: string): void;'
+      const newContent = 'export declare function fn(arg0?: string): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      // Adding optional marker should be detected as widening
+      const fn = result.changes.find((c) => c.symbolName === 'fn')
+      expect(fn?.category).toBe('type-widened')
+    })
+
+    it('preserves question marks in nested object types', () => {
+      const oldContent =
+        'export declare function fn(opts: { name?: string }): void;'
+      const newContent =
+        'export declare function fn(opts: { name?: string; age: number }): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      // Should detect a breaking change (required property added to parameter type)
+      const fn = result.changes.find((c) => c.symbolName === 'fn')
+      expect(fn?.releaseType).toBe('major')
+    })
+
+    it('preserves question marks in conditional types', () => {
+      const oldContent =
+        'export type Result<T> = T extends string ? string : number;'
+      const newContent =
+        'export type Result<T> = T extends string ? string : boolean;'
+      const result = compareStrings(oldContent, newContent)
+
+      const resultType = result.changes.find((c) => c.symbolName === 'Result')
+      expect(resultType?.releaseType).toBe('major')
+    })
+
+    it('handles multiple optional parameters correctly', () => {
+      const oldContent =
+        'export declare function fn(a: string, b: number): void;'
+      const newContent =
+        'export declare function fn(a?: string, b?: number): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const fn = result.changes.find((c) => c.symbolName === 'fn')
+      expect(fn?.category).toBe('type-widened')
+      expect(fn?.releaseType).toBe('minor')
+    })
+  })
+
+  describe('type changes', () => {
+    it('detects interface property addition as major', () => {
+      const oldContent = 'export interface User { name: string; }'
+      const newContent = 'export interface User { name: string; age: number; }'
+      const result = compareStrings(oldContent, newContent)
+
+      const user = result.changes.find((c) => c.symbolName === 'User')
+      expect(user?.releaseType).toBe('major')
+    })
+
+    it('detects interface property removal as major', () => {
+      const oldContent = 'export interface User { name: string; age: number; }'
+      const newContent = 'export interface User { name: string; }'
+      const result = compareStrings(oldContent, newContent)
+
+      const user = result.changes.find((c) => c.symbolName === 'User')
+      expect(user?.releaseType).toBe('major')
+    })
+
+    it('detects type alias change as major', () => {
+      const oldContent = "export type Status = 'active' | 'inactive';"
+      const newContent = "export type Status = 'active' | 'pending';"
+      const result = compareStrings(oldContent, newContent)
+
+      const status = result.changes.find((c) => c.symbolName === 'Status')
+      expect(status?.releaseType).toBe('major')
+    })
+  })
+
+  describe('class changes', () => {
+    it('detects added constructor parameter as major', () => {
+      const oldContent = `
+        export declare class User {
+          constructor(name: string);
+        }
+      `
+      const newContent = `
+        export declare class User {
+          constructor(name: string, age: number);
+        }
+      `
+      const result = compareStrings(oldContent, newContent)
+
+      const user = result.changes.find((c) => c.symbolName === 'User')
+      expect(user?.releaseType).toBe('major')
+    })
+
+    it('detects added method as major (class structure change)', () => {
+      const oldContent = `
+        export declare class Service {
+          start(): void;
+        }
+      `
+      const newContent = `
+        export declare class Service {
+          start(): void;
+          stop(): void;
+        }
+      `
+      const result = compareStrings(oldContent, newContent)
+
+      const service = result.changes.find((c) => c.symbolName === 'Service')
+      expect(service?.releaseType).toBe('major')
+    })
+  })
+
+  describe('explanation generation', () => {
+    it('includes before/after signatures in explanation when different', () => {
+      const oldContent = 'export declare function foo(x: string): void;'
+      const newContent = 'export declare function foo(x: number): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const foo = result.changes.find((c) => c.symbolName === 'foo')
+      expect(foo?.explanation).toContain('was:')
+      expect(foo?.explanation).toContain('now:')
+    })
+
+    it('generates appropriate explanation for symbol removal', () => {
+      const oldContent = 'export declare function foo(): void;'
+      const newContent = ''
+      const result = compareStrings(oldContent, newContent)
+
+      const foo = result.changes.find((c) => c.symbolName === 'foo')
+      expect(foo?.explanation).toContain('Removed')
+      expect(foo?.explanation).toContain('foo')
+    })
+
+    it('generates appropriate explanation for symbol addition', () => {
+      const oldContent = ''
+      const newContent = 'export declare function bar(): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      const bar = result.changes.find((c) => c.symbolName === 'bar')
+      expect(bar?.explanation).toContain('Added')
+      expect(bar?.explanation).toContain('bar')
+    })
+  })
+
+  describe('error handling', () => {
+    it('captures parsing errors but continues comparison', () => {
+      // Syntax error in old file
+      const oldContent = 'export declare function foo(: void;' // Missing param name
+      const newContent = 'export declare function bar(): void;'
+      const result = compareStrings(oldContent, newContent)
+
+      // Should still return a result
+      expect(result).toBeDefined()
+    })
+  })
+})
+
+describe('compareDeclarationResults', () => {
+  it('combines errors from both parse results', () => {
+    const oldParsed = parseDeclarationStringWithTypes(
+      'export declare function foo(): void;',
+      ts,
+      'old.d.ts',
+    )
+    const newParsed = parseDeclarationStringWithTypes(
+      'export declare function foo(): void;',
+      ts,
+      'new.d.ts',
+    )
+
+    // Manually add errors to simulate parsing issues
+    oldParsed.errors.push('Old file error')
+    newParsed.errors.push('New file error')
+
+    const result = compareDeclarationResults(oldParsed, newParsed, ts)
+
+    expect(result.errors).toContain('Old file error')
+    expect(result.errors).toContain('New file error')
+  })
+
+  it('handles symbols without type information gracefully', () => {
+    const oldParsed = parseDeclarationStringWithTypes(
+      'export declare const x: string;',
+      ts,
+      'old.d.ts',
+    )
+    const newParsed = parseDeclarationStringWithTypes(
+      'export declare const x: number;',
+      ts,
+      'new.d.ts',
+    )
+
+    // Clear type symbols to simulate missing type info
+    oldParsed.typeSymbols.clear()
+
+    const result = compareDeclarationResults(oldParsed, newParsed, ts)
+
+    // Should still detect the change via signature comparison
+    const x = result.changes.find((c) => c.symbolName === 'x')
+    expect(x).toBeDefined()
+    expect(x?.releaseType).toBe('major')
+  })
+
+  it('correctly identifies interface vs type alias declarations', () => {
+    const oldInterface = `
+      export interface Config {
+        name: string;
+      }
+    `
+    const newInterface = `
+      export interface Config {
+        name: string;
+        value: number;
+      }
+    `
+
+    const oldParsed = parseDeclarationStringWithTypes(oldInterface, ts)
+    const newParsed = parseDeclarationStringWithTypes(newInterface, ts)
+    const result = compareDeclarationResults(oldParsed, newParsed, ts)
+
+    const config = result.changes.find((c) => c.symbolName === 'Config')
+    expect(config).toBeDefined()
+    expect(config?.symbolKind).toBe('interface')
+  })
+})
+
+describe('signature analysis edge cases', () => {
+  it('handles overloaded functions', () => {
+    const oldContent = `
+      export declare function process(x: string): string;
+      export declare function process(x: number): number;
+    `
+    const newContent = `
+      export declare function process(x: string): string;
+      export declare function process(x: number): number;
+      export declare function process(x: boolean): boolean;
+    `
+    const result = compareStrings(oldContent, newContent)
+
+    const process = result.changes.find((c) => c.symbolName === 'process')
+    expect(process).toBeDefined()
+    // Adding overload is a change
+    expect(process?.releaseType).toBe('major')
+  })
+
+  it('handles generic functions', () => {
+    const oldContent = 'export declare function identity<T>(x: T): T;'
+    const newContent = 'export declare function identity<T>(x: T): T;'
+    const result = compareStrings(oldContent, newContent)
+
+    const identity = result.changes.find((c) => c.symbolName === 'identity')
+    expect(identity?.category).toBe('signature-identical')
+  })
+
+  it('handles generic constraint changes', () => {
+    const oldContent =
+      'export declare function process<T extends object>(x: T): T;'
+    const newContent =
+      'export declare function process<T extends string>(x: T): T;'
+    const result = compareStrings(oldContent, newContent)
+
+    const process = result.changes.find((c) => c.symbolName === 'process')
+    expect(process?.releaseType).toBe('major')
+  })
+
+  it('normalizes generic type parameter names', () => {
+    // Same function with different type parameter names should be identical
+    const oldContent = 'export declare function identity<T>(x: T): T;'
+    const newContent = 'export declare function identity<U>(x: U): U;'
+    const result = compareStrings(oldContent, newContent)
+
+    const identity = result.changes.find((c) => c.symbolName === 'identity')
+    expect(identity?.category).toBe('signature-identical')
+  })
+
+  it('handles async function return types', () => {
+    const oldContent = 'export declare function fetchData(): Promise<string>;'
+    const newContent = 'export declare function fetchData(): Promise<number>;'
+    const result = compareStrings(oldContent, newContent)
+
+    const fetchData = result.changes.find((c) => c.symbolName === 'fetchData')
+    expect(fetchData?.category).toBe('return-type-changed')
+    expect(fetchData?.releaseType).toBe('major')
+  })
+})
+
+describe('construct signatures', () => {
+  it('detects constructor signature changes', () => {
+    const oldContent = `
+      export declare class Point {
+        constructor(x: number, y: number);
+      }
+    `
+    const newContent = `
+      export declare class Point {
+        constructor(x: number, y: number, z: number);
+      }
+    `
+    const result = compareStrings(oldContent, newContent)
+
+    const point = result.changes.find((c) => c.symbolName === 'Point')
+    expect(point?.releaseType).toBe('major')
+  })
+
+  it('detects added optional constructor parameter as change', () => {
+    const oldContent = `
+      export declare class Point {
+        constructor(x: number, y: number);
+      }
+    `
+    const newContent = `
+      export declare class Point {
+        constructor(x: number, y: number, z?: number);
+      }
+    `
+    const result = compareStrings(oldContent, newContent)
+
+    const point = result.changes.find((c) => c.symbolName === 'Point')
+    // Class signature still changes, even if optional
+    expect(point).toBeDefined()
+  })
+})

--- a/tools/change-detector-core/test/parser-core.test.ts
+++ b/tools/change-detector-core/test/parser-core.test.ts
@@ -1,0 +1,775 @@
+import { describe, it, expect } from 'vitest'
+import * as ts from 'typescript'
+import {
+  parseDeclarationString,
+  parseDeclarationStringWithTypes,
+  createInMemoryCompilerHost,
+} from '../src/parser-core'
+
+describe('parseDeclarationString', () => {
+  describe('basic parsing', () => {
+    it('parses empty content', () => {
+      const result = parseDeclarationString('', ts)
+
+      expect(result.symbols.size).toBe(0)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('parses whitespace-only content', () => {
+      const result = parseDeclarationString('   \n\t  ', ts)
+
+      expect(result.symbols.size).toBe(0)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('parses comment-only content', () => {
+      const result = parseDeclarationString('// just a comment', ts)
+
+      expect(result.symbols.size).toBe(0)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('uses custom filename when provided', () => {
+      const result = parseDeclarationString(
+        'export declare function foo(): void;',
+        ts,
+        'custom.d.ts',
+      )
+
+      expect(result.symbols.size).toBe(1)
+      expect(result.errors).toHaveLength(0)
+    })
+  })
+
+  describe('symbol kind detection', () => {
+    it('detects function declarations', () => {
+      const result = parseDeclarationString(
+        'export declare function myFunc(): void;',
+        ts,
+      )
+
+      const myFunc = result.symbols.get('myFunc')
+      expect(myFunc).toBeDefined()
+      expect(myFunc?.kind).toBe('function')
+    })
+
+    it('detects class declarations', () => {
+      const result = parseDeclarationString(
+        'export declare class MyClass {}',
+        ts,
+      )
+
+      const myClass = result.symbols.get('MyClass')
+      expect(myClass).toBeDefined()
+      expect(myClass?.kind).toBe('class')
+    })
+
+    it('detects interface declarations', () => {
+      const result = parseDeclarationString(
+        'export interface MyInterface { name: string; }',
+        ts,
+      )
+
+      const myInterface = result.symbols.get('MyInterface')
+      expect(myInterface).toBeDefined()
+      expect(myInterface?.kind).toBe('interface')
+    })
+
+    it('detects type alias declarations', () => {
+      const result = parseDeclarationString(
+        'export type MyType = string | number;',
+        ts,
+      )
+
+      const myType = result.symbols.get('MyType')
+      expect(myType).toBeDefined()
+      expect(myType?.kind).toBe('type')
+    })
+
+    it('detects enum declarations', () => {
+      const result = parseDeclarationString(
+        'export enum MyEnum { A, B, C }',
+        ts,
+      )
+
+      const myEnum = result.symbols.get('MyEnum')
+      expect(myEnum).toBeDefined()
+      expect(myEnum?.kind).toBe('enum')
+    })
+
+    it('detects namespace declarations', () => {
+      const result = parseDeclarationString(
+        'export declare namespace MyNamespace { function helper(): void; }',
+        ts,
+      )
+
+      const myNamespace = result.symbols.get('MyNamespace')
+      expect(myNamespace).toBeDefined()
+      expect(myNamespace?.kind).toBe('namespace')
+    })
+
+    it('detects variable declarations', () => {
+      const result = parseDeclarationString(
+        'export declare const myVar: string;',
+        ts,
+      )
+
+      const myVar = result.symbols.get('myVar')
+      expect(myVar).toBeDefined()
+      expect(myVar?.kind).toBe('variable')
+    })
+
+    it('detects arrow function variables as functions', () => {
+      const result = parseDeclarationString(
+        'export declare const myArrowFn: (x: string) => number;',
+        ts,
+      )
+
+      const myArrowFn = result.symbols.get('myArrowFn')
+      expect(myArrowFn).toBeDefined()
+      expect(myArrowFn?.kind).toBe('function')
+    })
+  })
+
+  describe('function signature parsing', () => {
+    it('parses simple function signature', () => {
+      const result = parseDeclarationString(
+        'export declare function greet(name: string): string;',
+        ts,
+      )
+
+      const greet = result.symbols.get('greet')
+      expect(greet?.signature).toContain('string')
+    })
+
+    it('parses function with multiple parameters', () => {
+      const result = parseDeclarationString(
+        'export declare function add(a: number, b: number): number;',
+        ts,
+      )
+
+      const add = result.symbols.get('add')
+      expect(add?.signature).toContain('number')
+    })
+
+    it('parses function with optional parameters', () => {
+      const result = parseDeclarationString(
+        'export declare function greet(name: string, prefix?: string): string;',
+        ts,
+      )
+
+      const greet = result.symbols.get('greet')
+      expect(greet?.signature).toContain('?')
+    })
+
+    it('parses function with rest parameters', () => {
+      const result = parseDeclarationString(
+        'export declare function log(msg: string, ...args: unknown[]): void;',
+        ts,
+      )
+
+      const log = result.symbols.get('log')
+      expect(log?.signature).toContain('...')
+    })
+
+    it('normalizes parameter names', () => {
+      const result = parseDeclarationString(
+        'export declare function fn(longParameterName: string): void;',
+        ts,
+      )
+
+      const fn = result.symbols.get('fn')
+      // Parameter names should be normalized to arg0, arg1, etc.
+      expect(fn?.signature).toContain('arg0')
+    })
+
+    it('parses overloaded functions', () => {
+      const result = parseDeclarationString(
+        `export declare function process(x: string): string;
+         export declare function process(x: number): number;`,
+        ts,
+      )
+
+      const process = result.symbols.get('process')
+      expect(process?.signature).toContain(';')
+    })
+  })
+
+  describe('generic function parsing', () => {
+    it('parses generic function', () => {
+      const result = parseDeclarationString(
+        'export declare function identity<T>(x: T): T;',
+        ts,
+      )
+
+      const identity = result.symbols.get('identity')
+      expect(identity?.signature).toContain('T0')
+    })
+
+    it('parses generic function with constraint', () => {
+      const result = parseDeclarationString(
+        'export declare function keys<T extends object>(obj: T): string[];',
+        ts,
+      )
+
+      const keys = result.symbols.get('keys')
+      expect(keys?.signature).toContain('extends')
+    })
+
+    it('parses generic function with default type', () => {
+      const result = parseDeclarationString(
+        'export declare function create<T = string>(): T;',
+        ts,
+      )
+
+      const create = result.symbols.get('create')
+      expect(create?.signature).toContain('=')
+    })
+
+    it('normalizes type parameter names', () => {
+      const result1 = parseDeclarationString(
+        'export declare function fn<T>(x: T): T;',
+        ts,
+      )
+      const result2 = parseDeclarationString(
+        'export declare function fn<U>(x: U): U;',
+        ts,
+      )
+
+      // Both should normalize to the same signature
+      expect(result1.symbols.get('fn')?.signature).toBe(
+        result2.symbols.get('fn')?.signature,
+      )
+    })
+  })
+
+  describe('interface signature parsing', () => {
+    it('parses simple interface', () => {
+      const result = parseDeclarationString(
+        'export interface User { name: string; age: number; }',
+        ts,
+      )
+
+      const user = result.symbols.get('User')
+      expect(user?.signature).toContain('name')
+      expect(user?.signature).toContain('age')
+    })
+
+    it('parses interface with optional properties', () => {
+      const result = parseDeclarationString(
+        'export interface Config { required: string; optional?: number; }',
+        ts,
+      )
+
+      const config = result.symbols.get('Config')
+      expect(config?.signature).toContain('optional?')
+    })
+
+    it('parses interface with readonly properties', () => {
+      const result = parseDeclarationString(
+        'export interface Point { readonly x: number; readonly y: number; }',
+        ts,
+      )
+
+      const point = result.symbols.get('Point')
+      expect(point?.signature).toContain('readonly')
+    })
+
+    it('parses interface with call signature', () => {
+      const result = parseDeclarationString(
+        'export interface Callable { (x: number): string; }',
+        ts,
+      )
+
+      const callable = result.symbols.get('Callable')
+      expect(callable?.signature).toContain('number')
+      expect(callable?.signature).toContain('string')
+    })
+
+    it('parses interface with construct signature', () => {
+      const result = parseDeclarationString(
+        'export interface Newable { new (x: string): object; }',
+        ts,
+      )
+
+      const newable = result.symbols.get('Newable')
+      expect(newable?.signature).toContain('new')
+    })
+
+    it('parses interface with index signature', () => {
+      const result = parseDeclarationString(
+        'export interface StringMap { [key: string]: number; }',
+        ts,
+      )
+
+      const stringMap = result.symbols.get('StringMap')
+      expect(stringMap?.signature).toContain('[key: string]')
+    })
+
+    it('parses generic interface', () => {
+      const result = parseDeclarationString(
+        'export interface Container<T> { value: T; }',
+        ts,
+      )
+
+      const container = result.symbols.get('Container')
+      expect(container?.signature).toContain('T0')
+    })
+
+    it('sorts properties alphabetically for consistent comparison', () => {
+      const result1 = parseDeclarationString(
+        'export interface Obj { b: number; a: string; }',
+        ts,
+      )
+      const result2 = parseDeclarationString(
+        'export interface Obj { a: string; b: number; }',
+        ts,
+      )
+
+      // Both should produce the same signature due to sorting
+      expect(result1.symbols.get('Obj')?.signature).toBe(
+        result2.symbols.get('Obj')?.signature,
+      )
+    })
+  })
+
+  describe('type alias signature parsing', () => {
+    it('parses simple type alias', () => {
+      const result = parseDeclarationString('export type ID = string;', ts)
+
+      const id = result.symbols.get('ID')
+      expect(id?.signature).toBe('string')
+    })
+
+    it('parses union type alias', () => {
+      const result = parseDeclarationString(
+        "export type Status = 'active' | 'inactive' | 'pending';",
+        ts,
+      )
+
+      const status = result.symbols.get('Status')
+      expect(status?.signature).toContain('|')
+    })
+
+    it('sorts union members for consistent comparison', () => {
+      const result1 = parseDeclarationString(
+        "export type Status = 'pending' | 'active';",
+        ts,
+      )
+      const result2 = parseDeclarationString(
+        "export type Status = 'active' | 'pending';",
+        ts,
+      )
+
+      expect(result1.symbols.get('Status')?.signature).toBe(
+        result2.symbols.get('Status')?.signature,
+      )
+    })
+
+    it('parses intersection type alias', () => {
+      const result = parseDeclarationString(
+        'export type Combined = { a: string } & { b: number };',
+        ts,
+      )
+
+      const combined = result.symbols.get('Combined')
+      expect(combined?.signature).toContain('&')
+    })
+
+    it('parses generic type alias', () => {
+      const result = parseDeclarationString(
+        'export type Wrapper<T> = { value: T };',
+        ts,
+      )
+
+      const wrapper = result.symbols.get('Wrapper')
+      expect(wrapper?.signature).toContain('T0')
+    })
+
+    it('parses object type alias with structural expansion', () => {
+      const result = parseDeclarationString(
+        'export type Config = { name: string; value: number };',
+        ts,
+      )
+
+      const config = result.symbols.get('Config')
+      expect(config?.signature).toContain('name')
+      expect(config?.signature).toContain('value')
+    })
+  })
+
+  describe('enum signature parsing', () => {
+    it('parses numeric enum', () => {
+      const result = parseDeclarationString(
+        'export enum Direction { Up, Down, Left, Right }',
+        ts,
+      )
+
+      const direction = result.symbols.get('Direction')
+      expect(direction?.signature).toContain('enum Direction')
+      expect(direction?.signature).toContain('Up')
+      expect(direction?.signature).toContain('Down')
+    })
+
+    it('parses string enum', () => {
+      const result = parseDeclarationString(
+        `export enum Color { Red = "RED", Green = "GREEN", Blue = "BLUE" }`,
+        ts,
+      )
+
+      const color = result.symbols.get('Color')
+      expect(color?.signature).toContain('enum Color')
+      expect(color?.signature).toContain('"RED"')
+    })
+
+    it('parses const enum', () => {
+      const result = parseDeclarationString(
+        'export const enum Status { Active = 1, Inactive = 0 }',
+        ts,
+      )
+
+      const status = result.symbols.get('Status')
+      expect(status?.signature).toContain('const enum')
+    })
+
+    it('includes enum member values', () => {
+      const result = parseDeclarationString(
+        'export enum Numbers { One = 1, Two = 2, Three = 3 }',
+        ts,
+      )
+
+      const numbers = result.symbols.get('Numbers')
+      expect(numbers?.signature).toContain('= 1')
+      expect(numbers?.signature).toContain('= 2')
+      expect(numbers?.signature).toContain('= 3')
+    })
+  })
+
+  describe('class signature parsing', () => {
+    it('parses simple class', () => {
+      const result = parseDeclarationString(
+        'export declare class MyClass {}',
+        ts,
+      )
+
+      const myClass = result.symbols.get('MyClass')
+      expect(myClass?.signature).toContain('class MyClass')
+    })
+
+    it('parses class with constructor', () => {
+      const result = parseDeclarationString(
+        `export declare class User {
+          constructor(name: string);
+        }`,
+        ts,
+      )
+
+      const user = result.symbols.get('User')
+      expect(user?.signature).toContain('constructor')
+    })
+
+    it('parses class with properties', () => {
+      const result = parseDeclarationString(
+        `export declare class Point {
+          x: number;
+          y: number;
+        }`,
+        ts,
+      )
+
+      const point = result.symbols.get('Point')
+      expect(point?.signature).toContain('x: number')
+      expect(point?.signature).toContain('y: number')
+    })
+
+    it('parses class with methods', () => {
+      const result = parseDeclarationString(
+        `export declare class Calculator {
+          add(a: number, b: number): number;
+        }`,
+        ts,
+      )
+
+      const calc = result.symbols.get('Calculator')
+      expect(calc?.signature).toContain('add')
+    })
+
+    it('parses abstract class', () => {
+      const result = parseDeclarationString(
+        'export declare abstract class Base { abstract method(): void; }',
+        ts,
+      )
+
+      const base = result.symbols.get('Base')
+      expect(base?.signature).toContain('abstract class')
+      expect(base?.signature).toContain('abstract method')
+    })
+
+    it('parses class with static members', () => {
+      const result = parseDeclarationString(
+        `export declare class Counter {
+          static count: number;
+          static increment(): void;
+        }`,
+        ts,
+      )
+
+      const counter = result.symbols.get('Counter')
+      expect(counter?.signature).toContain('static count')
+      expect(counter?.signature).toContain('static increment')
+    })
+
+    it('parses class with readonly properties', () => {
+      const result = parseDeclarationString(
+        `export declare class Config {
+          readonly version: string;
+        }`,
+        ts,
+      )
+
+      const config = result.symbols.get('Config')
+      expect(config?.signature).toContain('readonly version')
+    })
+
+    it('parses class with optional properties', () => {
+      const result = parseDeclarationString(
+        `export declare class Options {
+          debug?: boolean;
+        }`,
+        ts,
+      )
+
+      const options = result.symbols.get('Options')
+      expect(options?.signature).toContain('debug?')
+    })
+
+    it('parses class with getters and setters', () => {
+      const result = parseDeclarationString(
+        `export declare class Person {
+          get name(): string;
+          set name(value: string);
+        }`,
+        ts,
+      )
+
+      const person = result.symbols.get('Person')
+      expect(person?.signature).toContain('get name')
+      expect(person?.signature).toContain('set name')
+    })
+
+    it('parses class extending another class', () => {
+      const result = parseDeclarationString(
+        `export declare class Animal {}
+         export declare class Dog extends Animal {}`,
+        ts,
+      )
+
+      const dog = result.symbols.get('Dog')
+      expect(dog?.signature).toContain('extends Animal')
+    })
+
+    it('parses class implementing interfaces', () => {
+      const result = parseDeclarationString(
+        `export interface Runnable { run(): void; }
+         export declare class Task implements Runnable { run(): void; }`,
+        ts,
+      )
+
+      const task = result.symbols.get('Task')
+      expect(task?.signature).toContain('implements Runnable')
+    })
+
+    it('parses generic class', () => {
+      const result = parseDeclarationString(
+        `export declare class Box<T> { value: T; }`,
+        ts,
+      )
+
+      const box = result.symbols.get('Box')
+      expect(box?.signature).toContain('<T>')
+    })
+  })
+
+  describe('namespace signature parsing', () => {
+    it('parses namespace with functions', () => {
+      const result = parseDeclarationString(
+        `export declare namespace Utils {
+          function helper(): void;
+        }`,
+        ts,
+      )
+
+      const utils = result.symbols.get('Utils')
+      expect(utils?.signature).toContain('namespace Utils')
+      expect(utils?.signature).toContain('helper')
+    })
+
+    it('parses empty namespace', () => {
+      const result = parseDeclarationString(
+        'export declare namespace Empty {}',
+        ts,
+      )
+
+      const empty = result.symbols.get('Empty')
+      expect(empty?.signature).toContain('namespace Empty {}')
+    })
+
+    it('parses namespace with multiple exports', () => {
+      const result = parseDeclarationString(
+        `export declare namespace Math {
+          const PI: number;
+          function add(a: number, b: number): number;
+        }`,
+        ts,
+      )
+
+      const math = result.symbols.get('Math')
+      expect(math?.signature).toContain('PI')
+      expect(math?.signature).toContain('add')
+    })
+  })
+
+  describe('export handling', () => {
+    it('handles re-exports with aliases', () => {
+      const result = parseDeclarationString(
+        `declare function internal(): void;
+         export { internal as external };`,
+        ts,
+      )
+
+      expect(result.symbols.has('external')).toBe(true)
+      expect(result.symbols.has('internal')).toBe(false)
+    })
+
+    it('handles default exports', () => {
+      const result = parseDeclarationString(
+        `declare function main(): void;
+         export default main;`,
+        ts,
+      )
+
+      expect(result.symbols.has('default')).toBe(true)
+    })
+  })
+})
+
+describe('parseDeclarationStringWithTypes', () => {
+  it('returns program and type checker', () => {
+    const result = parseDeclarationStringWithTypes(
+      'export declare function foo(): void;',
+      ts,
+    )
+
+    expect(result.program).toBeDefined()
+    expect(result.checker).toBeDefined()
+  })
+
+  it('returns type symbols for each export', () => {
+    const result = parseDeclarationStringWithTypes(
+      `export declare function foo(): void;
+       export interface Bar { x: number; }`,
+      ts,
+    )
+
+    expect(result.typeSymbols.has('foo')).toBe(true)
+    expect(result.typeSymbols.has('Bar')).toBe(true)
+  })
+
+  it('handles empty content', () => {
+    const result = parseDeclarationStringWithTypes('', ts)
+
+    expect(result.symbols.size).toBe(0)
+    expect(result.errors).toHaveLength(0)
+    expect(result.program).toBeDefined()
+    expect(result.checker).toBeDefined()
+  })
+
+  it('resolves aliased symbols', () => {
+    const result = parseDeclarationStringWithTypes(
+      `declare function internal(): void;
+       export { internal as external };`,
+      ts,
+    )
+
+    const external = result.typeSymbols.get('external')
+    expect(external).toBeDefined()
+    // The type symbol should be the resolved (non-alias) symbol
+  })
+})
+
+describe('createInMemoryCompilerHost', () => {
+  it('provides file content for registered files', () => {
+    const files = new Map<string, string>()
+    files.set('test.ts', 'const x = 1;')
+
+    const host = createInMemoryCompilerHost(files, ts)
+
+    expect(host.fileExists('test.ts')).toBe(true)
+    expect(host.readFile('test.ts')).toBe('const x = 1;')
+  })
+
+  it('returns false for non-existent files', () => {
+    const files = new Map<string, string>()
+    const host = createInMemoryCompilerHost(files, ts)
+
+    expect(host.fileExists('nonexistent.ts')).toBe(false)
+    expect(host.readFile('nonexistent.ts')).toBeUndefined()
+  })
+
+  it('provides empty source for lib files', () => {
+    const files = new Map<string, string>()
+    const host = createInMemoryCompilerHost(files, ts)
+
+    // Should return empty source file for lib files
+    const sourceFile = host.getSourceFile(
+      'lib.es5.d.ts',
+      ts.ScriptTarget.Latest,
+    )
+    expect(sourceFile).toBeDefined()
+  })
+
+  it('returns undefined for non-lib files that do not exist', () => {
+    const files = new Map<string, string>()
+    const host = createInMemoryCompilerHost(files, ts)
+
+    const sourceFile = host.getSourceFile('random.ts', ts.ScriptTarget.Latest)
+    expect(sourceFile).toBeUndefined()
+  })
+
+  it('implements required CompilerHost methods', () => {
+    const files = new Map<string, string>()
+    const host = createInMemoryCompilerHost(files, ts)
+
+    expect(host.getDefaultLibFileName({})).toBeDefined()
+    expect(host.getCurrentDirectory()).toBe('/')
+    expect(host.getCanonicalFileName('Test.ts')).toBe('Test.ts')
+    expect(host.useCaseSensitiveFileNames()).toBe(true)
+    expect(host.getNewLine()).toBe('\n')
+    expect(host.directoryExists('/')).toBe(true)
+    expect(host.getDirectories('/')).toEqual([])
+  })
+})
+
+describe('error handling', () => {
+  it('captures errors for invalid symbols', () => {
+    // This tests that errors during symbol processing are captured
+    // rather than causing the entire parse to fail
+    const result = parseDeclarationString(
+      'export declare function valid(): void;',
+      ts,
+    )
+
+    // Should still parse the valid symbol
+    expect(result.symbols.has('valid')).toBe(true)
+  })
+
+  it('records source file parse errors', () => {
+    const result = parseDeclarationStringWithTypes(
+      'export declare function;', // syntax error
+      ts,
+    )
+
+    // The result should still be defined even with syntax errors
+    expect(result).toBeDefined()
+  })
+})

--- a/tools/change-detector-semantic-release-plugin/src/analyzer.ts
+++ b/tools/change-detector-semantic-release-plugin/src/analyzer.ts
@@ -48,6 +48,13 @@ export function findDeclarationFile(
     main?: string
   }
 
+  // Error if both types and typings are specified - there's no good reason to use both
+  if (pkgJson.types && pkgJson.typings) {
+    throw new Error(
+      "package.json has both 'types' and 'typings' fields. Please use only 'types' (the 'typings' field is deprecated).",
+    )
+  }
+
   // Check "types" field
   if (pkgJson.types) {
     const typesPath = path.join(cwd, pkgJson.types)
@@ -56,7 +63,7 @@ export function findDeclarationFile(
     }
   }
 
-  // Check "typings" field (alternative to types)
+  // Check "typings" field (legacy alternative to types)
   if (pkgJson.typings) {
     const typingsPath = path.join(cwd, pkgJson.typings)
     if (fs.existsSync(typingsPath)) {

--- a/tools/change-detector-semantic-release-plugin/test/analyzer.test.ts
+++ b/tools/change-detector-semantic-release-plugin/test/analyzer.test.ts
@@ -1,0 +1,476 @@
+/**
+ * Tests for the analyzer module.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { Project } from 'fixturify-project'
+import { findDeclarationFile, formatChangeSummary } from '../src/analyzer'
+import { resolveConfig, type ResolvedPluginConfig } from '../src/types'
+import type { ComparisonReport } from '@api-extractor-tools/change-detector'
+
+describe('findDeclarationFile', () => {
+  let project: Project
+
+  beforeEach(() => {
+    project = new Project('test-package')
+  })
+
+  afterEach(() => {
+    project.dispose()
+  })
+
+  describe('explicit path', () => {
+    it('returns absolute path when file exists', async () => {
+      project.files = {
+        'package.json': JSON.stringify({ name: '@test/pkg' }),
+        lib: {
+          'types.d.ts': 'export declare function foo(): void;',
+        },
+      }
+      await project.write()
+
+      const config: ResolvedPluginConfig = {
+        ...resolveConfig(),
+        declarationPath: 'lib/types.d.ts',
+      }
+
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toContain('lib/types.d.ts')
+    })
+
+    it('returns null when explicit path file does not exist', async () => {
+      project.files = {
+        'package.json': JSON.stringify({ name: '@test/pkg' }),
+      }
+      await project.write()
+
+      const config: ResolvedPluginConfig = {
+        ...resolveConfig(),
+        declarationPath: 'nonexistent.d.ts',
+      }
+
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toBeNull()
+    })
+
+    it('handles absolute explicit paths', async () => {
+      project.files = {
+        'package.json': JSON.stringify({ name: '@test/pkg' }),
+        dist: {
+          'index.d.ts': 'export declare function foo(): void;',
+        },
+      }
+      await project.write()
+
+      const config: ResolvedPluginConfig = {
+        ...resolveConfig(),
+        declarationPath: `${project.baseDir}/dist/index.d.ts`,
+      }
+
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toBe(`${project.baseDir}/dist/index.d.ts`)
+    })
+  })
+
+  describe('package.json types field', () => {
+    it('finds declaration from types field', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: '@test/pkg',
+          types: 'dist/index.d.ts',
+        }),
+        dist: {
+          'index.d.ts': 'export declare function foo(): void;',
+        },
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toContain('dist/index.d.ts')
+    })
+
+    it('throws error when both types and typings fields are present', async () => {
+      // Having both types and typings is redundant and confusing
+      // Use pkg property to set package.json fields (fixturify-project API)
+      project.pkg = {
+        name: '@test/pkg',
+        types: 'dist/index.d.ts',
+        typings: 'lib/types.d.ts',
+      }
+      project.files = {
+        dist: {
+          'index.d.ts': 'export declare function foo(): void;',
+        },
+        lib: {
+          'types.d.ts': 'export declare function bar(): void;',
+        },
+      }
+      await project.write()
+
+      const config = resolveConfig()
+
+      expect(() => findDeclarationFile(project.baseDir, config)).toThrow(
+        /both 'types' and 'typings'/,
+      )
+    })
+
+    it('finds declaration from typings field when types is not present', async () => {
+      // typings is a legacy field but should still work alone
+      project.files = {
+        'package.json': JSON.stringify({
+          name: '@test/pkg',
+          typings: 'dist/index.d.ts',
+        }),
+        dist: {
+          'index.d.ts': 'export declare function bar(): void;',
+        },
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toContain('dist/index.d.ts')
+    })
+
+    it('returns null when types field points to missing file', async () => {
+      project.files = {
+        'package.json': JSON.stringify({
+          name: '@test/pkg',
+          types: 'dist/index.d.ts',
+        }),
+        // Note: dist/index.d.ts is not created
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('fallback to common locations', () => {
+    it('tries common locations when no explicit types field', async () => {
+      // Even with a main field, if the derived .d.ts doesn't exist,
+      // it falls back to common locations
+      project.files = {
+        'package.json': JSON.stringify({
+          name: '@test/pkg',
+          main: 'dist/main.js',
+        }),
+        dist: {
+          'main.js': 'module.exports = {};',
+          'index.d.ts': 'export declare function main(): void;',
+        },
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      // Falls back to common location dist/index.d.ts
+      expect(result).toContain('dist/index.d.ts')
+    })
+  })
+
+  describe('common locations', () => {
+    it('finds dist/index.d.ts', async () => {
+      project.files = {
+        'package.json': JSON.stringify({ name: '@test/pkg' }),
+        dist: {
+          'index.d.ts': 'export declare function foo(): void;',
+        },
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toContain('dist/index.d.ts')
+    })
+
+    it('finds lib/index.d.ts', async () => {
+      project.files = {
+        'package.json': JSON.stringify({ name: '@test/pkg' }),
+        lib: {
+          'index.d.ts': 'export declare function foo(): void;',
+        },
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toContain('lib/index.d.ts')
+    })
+
+    it('finds build/index.d.ts', async () => {
+      project.files = {
+        'package.json': JSON.stringify({ name: '@test/pkg' }),
+        build: {
+          'index.d.ts': 'export declare function foo(): void;',
+        },
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toContain('build/index.d.ts')
+    })
+
+    it('finds root index.d.ts', async () => {
+      project.files = {
+        'package.json': JSON.stringify({ name: '@test/pkg' }),
+        'index.d.ts': 'export declare function foo(): void;',
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toContain('index.d.ts')
+    })
+
+    it('prefers dist over lib', async () => {
+      project.files = {
+        'package.json': JSON.stringify({ name: '@test/pkg' }),
+        dist: {
+          'index.d.ts': 'export declare function dist(): void;',
+        },
+        lib: {
+          'index.d.ts': 'export declare function lib(): void;',
+        },
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toContain('dist/index.d.ts')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns null when no package.json exists', async () => {
+      project.files = {
+        dist: {
+          'index.d.ts': 'export declare function foo(): void;',
+        },
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      // Should fall back to common locations
+      expect(result).toContain('dist/index.d.ts')
+    })
+
+    it('returns null when no declaration file found anywhere', async () => {
+      project.files = {
+        'package.json': JSON.stringify({ name: '@test/pkg' }),
+        src: {
+          'index.ts': 'export function foo() {}',
+        },
+      }
+      await project.write()
+
+      const config = resolveConfig()
+      const result = findDeclarationFile(project.baseDir, config)
+
+      expect(result).toBeNull()
+    })
+  })
+})
+
+describe('formatChangeSummary', () => {
+  it('returns default message for null report', () => {
+    const result = formatChangeSummary(null)
+
+    expect(result).toBe('No API changes detected')
+  })
+
+  it('returns default message for report with no changes', () => {
+    const report: ComparisonReport = {
+      releaseType: 'none',
+      changes: {
+        breaking: [],
+        nonBreaking: [],
+        unchanged: [],
+      },
+      stats: {
+        totalSymbolsOld: 5,
+        totalSymbolsNew: 5,
+        added: 0,
+        removed: 0,
+        modified: 0,
+        unchanged: 5,
+      },
+      oldFile: 'old.d.ts',
+      newFile: 'new.d.ts',
+    }
+
+    const result = formatChangeSummary(report)
+
+    expect(result).toBe('No API changes detected')
+  })
+
+  it('formats breaking changes only', () => {
+    const report: ComparisonReport = {
+      releaseType: 'major',
+      changes: {
+        breaking: [
+          {
+            symbolName: 'foo',
+            symbolKind: 'function',
+            category: 'symbol-removed',
+            releaseType: 'major',
+            explanation: 'Removed',
+          },
+        ],
+        nonBreaking: [],
+        unchanged: [],
+      },
+      stats: {
+        totalSymbolsOld: 1,
+        totalSymbolsNew: 0,
+        added: 0,
+        removed: 1,
+        modified: 0,
+        unchanged: 0,
+      },
+      oldFile: 'old.d.ts',
+      newFile: 'new.d.ts',
+    }
+
+    const result = formatChangeSummary(report)
+
+    expect(result).toContain('1 breaking change(s)')
+    expect(result).toContain('1 removed')
+  })
+
+  it('formats non-breaking changes only', () => {
+    const report: ComparisonReport = {
+      releaseType: 'minor',
+      changes: {
+        breaking: [],
+        nonBreaking: [
+          {
+            symbolName: 'bar',
+            symbolKind: 'function',
+            category: 'symbol-added',
+            releaseType: 'minor',
+            explanation: 'Added',
+          },
+          {
+            symbolName: 'baz',
+            symbolKind: 'function',
+            category: 'symbol-added',
+            releaseType: 'minor',
+            explanation: 'Added',
+          },
+        ],
+        unchanged: [],
+      },
+      stats: {
+        totalSymbolsOld: 0,
+        totalSymbolsNew: 2,
+        added: 2,
+        removed: 0,
+        modified: 0,
+        unchanged: 0,
+      },
+      oldFile: 'old.d.ts',
+      newFile: 'new.d.ts',
+    }
+
+    const result = formatChangeSummary(report)
+
+    expect(result).toContain('2 non-breaking change(s)')
+    expect(result).toContain('2 added')
+  })
+
+  it('formats mixed changes', () => {
+    const report: ComparisonReport = {
+      releaseType: 'major',
+      changes: {
+        breaking: [
+          {
+            symbolName: 'foo',
+            symbolKind: 'function',
+            category: 'symbol-removed',
+            releaseType: 'major',
+            explanation: 'Removed',
+          },
+        ],
+        nonBreaking: [
+          {
+            symbolName: 'bar',
+            symbolKind: 'function',
+            category: 'symbol-added',
+            releaseType: 'minor',
+            explanation: 'Added',
+          },
+        ],
+        unchanged: [],
+      },
+      stats: {
+        totalSymbolsOld: 2,
+        totalSymbolsNew: 2,
+        added: 1,
+        removed: 1,
+        modified: 0,
+        unchanged: 0,
+      },
+      oldFile: 'old.d.ts',
+      newFile: 'new.d.ts',
+    }
+
+    const result = formatChangeSummary(report)
+
+    expect(result).toContain('1 breaking change(s)')
+    expect(result).toContain('1 non-breaking change(s)')
+    expect(result).toContain('1 added')
+    expect(result).toContain('1 removed')
+  })
+
+  it('includes modification count', () => {
+    const report: ComparisonReport = {
+      releaseType: 'major',
+      changes: {
+        breaking: [
+          {
+            symbolName: 'foo',
+            symbolKind: 'function',
+            category: 'return-type-changed',
+            releaseType: 'major',
+            explanation: 'Return type changed',
+          },
+        ],
+        nonBreaking: [],
+        unchanged: [],
+      },
+      stats: {
+        totalSymbolsOld: 1,
+        totalSymbolsNew: 1,
+        added: 0,
+        removed: 0,
+        modified: 1,
+        unchanged: 0,
+      },
+      oldFile: 'old.d.ts',
+      newFile: 'new.d.ts',
+    }
+
+    const result = formatChangeSummary(report)
+
+    expect(result).toContain('1 modified')
+  })
+})

--- a/tools/demo-site/test/encoding.test.ts
+++ b/tools/demo-site/test/encoding.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { encodeBase64, decodeBase64 } from '../src/utils/encoding'
+
+describe('encodeBase64', () => {
+  it('encodes simple ASCII string', () => {
+    const result = encodeBase64('hello')
+
+    expect(result).toBe('aGVsbG8=')
+  })
+
+  it('encodes empty string', () => {
+    const result = encodeBase64('')
+
+    expect(result).toBe('')
+  })
+
+  it('encodes string with spaces', () => {
+    const result = encodeBase64('hello world')
+
+    expect(result).toBe('aGVsbG8gd29ybGQ=')
+  })
+
+  it('encodes string with special characters', () => {
+    const input = 'Hello, World! @#$%^&*()'
+    const encoded = encodeBase64(input)
+
+    // Should be decodable back to original
+    expect(decodeBase64(encoded)).toBe(input)
+  })
+
+  it('encodes emoji characters', () => {
+    const input = '😀🎉🚀'
+    const encoded = encodeBase64(input)
+
+    // Should be decodable back to original
+    expect(decodeBase64(encoded)).toBe(input)
+  })
+
+  it('encodes non-ASCII characters (UTF-8)', () => {
+    const input = '日本語テスト'
+    const encoded = encodeBase64(input)
+
+    // Should be decodable back to original
+    expect(decodeBase64(encoded)).toBe(input)
+  })
+
+  it('encodes mixed content', () => {
+    const input = 'Hello 世界 🌍!'
+    const encoded = encodeBase64(input)
+
+    // Should be decodable back to original
+    expect(decodeBase64(encoded)).toBe(input)
+  })
+
+  it('encodes newlines and whitespace', () => {
+    const input = 'line1\nline2\ttab'
+    const encoded = encodeBase64(input)
+
+    expect(decodeBase64(encoded)).toBe(input)
+  })
+
+  it('encodes declaration file content', () => {
+    const input = 'export declare function foo(): void;'
+    const encoded = encodeBase64(input)
+
+    expect(decodeBase64(encoded)).toBe(input)
+  })
+})
+
+describe('decodeBase64', () => {
+  it('decodes simple ASCII string', () => {
+    const result = decodeBase64('aGVsbG8=')
+
+    expect(result).toBe('hello')
+  })
+
+  it('decodes empty string', () => {
+    const result = decodeBase64('')
+
+    expect(result).toBe('')
+  })
+
+  it('returns empty string for invalid base64', () => {
+    const result = decodeBase64('not-valid-base64!')
+
+    expect(result).toBe('')
+  })
+
+  it('returns empty string for truncated base64', () => {
+    // Missing padding - atob handles this, but we test for graceful handling
+    const result = decodeBase64('!!!invalid!!!')
+
+    // Should return empty string on decode failure
+    expect(result).toBe('')
+  })
+
+  it('decodes standard base64 alphabet correctly', () => {
+    // Test with characters from the full base64 alphabet
+    const original = 'The quick brown fox jumps over the lazy dog 0123456789'
+    const encoded = encodeBase64(original)
+    const decoded = decodeBase64(encoded)
+
+    expect(decoded).toBe(original)
+  })
+})
+
+describe('roundtrip encoding/decoding', () => {
+  const testCases = [
+    'simple text',
+    '',
+    'line1\nline2',
+    '   spaces   ',
+    'unicode: αβγδ',
+    'emoji: 🎉💻🔥',
+    'mixed: Hello 世界 🌍!',
+    'export declare function greet(name: string): string;',
+    'interface User {\n  name: string;\n  age: number;\n}',
+    'type Status = "active" | "inactive" | "pending";',
+  ]
+
+  testCases.forEach((input) => {
+    it(`roundtrips: "${input.slice(0, 30)}${input.length > 30 ? '...' : ''}"`, () => {
+      const encoded = encodeBase64(input)
+      const decoded = decodeBase64(encoded)
+
+      expect(decoded).toBe(input)
+    })
+  })
+})

--- a/tools/demo-site/test/urlLimits.test.ts
+++ b/tools/demo-site/test/urlLimits.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getMaxUrlLength, isUrlTooLong } from '../src/utils/urlLimits'
+
+describe('urlLimits', () => {
+  const originalNavigator = window.navigator
+
+  beforeEach(() => {
+    // Reset navigator mock before each test
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    // Restore original navigator
+    Object.defineProperty(window, 'navigator', {
+      value: originalNavigator,
+      writable: true,
+    })
+  })
+
+  function mockUserAgent(userAgent: string) {
+    Object.defineProperty(window, 'navigator', {
+      value: { userAgent },
+      writable: true,
+    })
+  }
+
+  describe('getMaxUrlLength', () => {
+    describe('Chromium-based browsers', () => {
+      it('returns 8000 for Chrome', () => {
+        mockUserAgent(
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        )
+
+        expect(getMaxUrlLength()).toBe(8000)
+      })
+
+      it('returns 8000 for Chromium', () => {
+        mockUserAgent(
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chromium/120.0.0.0 Safari/537.36',
+        )
+
+        expect(getMaxUrlLength()).toBe(8000)
+      })
+
+      it('returns 8000 for Edge', () => {
+        mockUserAgent(
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
+        )
+
+        expect(getMaxUrlLength()).toBe(8000)
+      })
+
+      it('returns 8000 for Opera', () => {
+        mockUserAgent(
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 OPR/106.0.0.0',
+        )
+
+        expect(getMaxUrlLength()).toBe(8000)
+      })
+    })
+
+    describe('non-Chromium browsers', () => {
+      it('returns 2000 for Safari', () => {
+        mockUserAgent(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+        )
+
+        expect(getMaxUrlLength()).toBe(2000)
+      })
+
+      it('returns 2000 for Firefox', () => {
+        mockUserAgent(
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0',
+        )
+
+        expect(getMaxUrlLength()).toBe(2000)
+      })
+
+      it('returns 2000 for unknown browsers', () => {
+        mockUserAgent('UnknownBrowser/1.0')
+
+        expect(getMaxUrlLength()).toBe(2000)
+      })
+    })
+  })
+
+  describe('isUrlTooLong', () => {
+    describe('with Chromium browser (8000 limit)', () => {
+      beforeEach(() => {
+        mockUserAgent('Chrome/120.0.0.0')
+      })
+
+      it('returns false for short URLs', () => {
+        const shortUrl = 'https://example.com/path?query=value'
+
+        expect(isUrlTooLong(shortUrl)).toBe(false)
+      })
+
+      it('returns false for URL exactly at limit', () => {
+        const urlAtLimit = 'a'.repeat(8000)
+
+        expect(isUrlTooLong(urlAtLimit)).toBe(false)
+      })
+
+      it('returns true for URL exceeding limit', () => {
+        const longUrl = 'a'.repeat(8001)
+
+        expect(isUrlTooLong(longUrl)).toBe(true)
+      })
+    })
+
+    describe('with non-Chromium browser (2000 limit)', () => {
+      beforeEach(() => {
+        mockUserAgent('Firefox/120.0')
+      })
+
+      it('returns false for short URLs', () => {
+        const shortUrl = 'https://example.com/path?query=value'
+
+        expect(isUrlTooLong(shortUrl)).toBe(false)
+      })
+
+      it('returns false for URL exactly at limit', () => {
+        const urlAtLimit = 'a'.repeat(2000)
+
+        expect(isUrlTooLong(urlAtLimit)).toBe(false)
+      })
+
+      it('returns true for URL exceeding limit', () => {
+        const longUrl = 'a'.repeat(2001)
+
+        expect(isUrlTooLong(longUrl)).toBe(true)
+      })
+
+      it('returns true for URL that would be fine in Chrome but not in Firefox', () => {
+        // URL that's 5000 chars - fine for Chrome, too long for Firefox
+        const mediumUrl = 'a'.repeat(5000)
+
+        expect(isUrlTooLong(mediumUrl)).toBe(true)
+      })
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty URL', () => {
+      mockUserAgent('Chrome/120.0.0.0')
+
+      expect(isUrlTooLong('')).toBe(false)
+    })
+
+    it('handles URL with special characters', () => {
+      mockUserAgent('Chrome/120.0.0.0')
+
+      const urlWithSpecialChars =
+        'https://example.com/path?emoji=🎉&text=hello%20world'
+
+      expect(isUrlTooLong(urlWithSpecialChars)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add comprehensive unit test coverage for previously untested internal modules
- Add validation error when `package.json` has both `types` and `typings` fields (redundant - `typings` is deprecated)

### Test Coverage Added

| Package | Module | Tests Added |
|---------|--------|-------------|
| `change-detector-core` | `comparator.ts` | 38 tests covering declaration comparison, parameter analysis, type change detection |
| `change-detector-core` | `parser-core.ts` | 68 tests covering TypeScript AST parsing, symbol extraction, signature normalization |
| `change-detector-semantic-release-plugin` | `analyzer.ts` | 21 tests covering declaration file discovery, change summary formatting |
| `demo-site` | `encoding.ts` | 24 tests covering Base64 encoding/decoding with UTF-8 support |
| `demo-site` | `urlLimits.ts` | 16 tests covering browser detection and URL length limits |

**Total: 167 new tests**

### Behavioral Change

The `findDeclarationFile` function in `change-detector-semantic-release-plugin` now throws an error if `package.json` has both `types` and `typings` fields. Previously, this ambiguous configuration would silently use `types`. The new behavior catches potential configuration mistakes early with a clear error message.

## Test Plan

- [x] All new tests pass locally (`pnpm test`)
- [x] Linting passes
- [x] API reports are up to date
- [x] Documentation is regenerated
- [x] Knip shows no issues (only configuration hints)