### PR TITLE
fix: combine release workflow version and publish into single job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,49 +11,14 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  version:
-    name: Create Release PR
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build
-
-      - name: Create Release Pull Request
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          version: pnpm changeset version
-          commit: "ci: version packages"
-          title: "ci: version packages"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish:
-    name: Publish to npm
+  release:
+    name: Release
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: npm-publish
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout
@@ -74,11 +39,14 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Publish to npm
+      - name: Create Release PR or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
+          version: pnpm changeset version
           publish: pnpm changeset publish --provenance
+          commit: "ci: version packages"
+          title: "ci: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

This is a follow-up fix to PR #50. While that PR fixed the permission issues, testing revealed a new problem: both the version and publish jobs were running simultaneously, causing conflicts.

## The Problem

After PR #50, the Release workflow had two jobs running in parallel:
1. **Version job**: Created/updated release PR #53
2. **Publish job**: Also tried to update PR #53 and failed with:
   ```
   HttpError: Resource not accessible by integration
   ```

Both jobs had the same condition (`workflow_run.conclusion == 'success'`), so they both ran on every push to main, regardless of whether changesets existed.

## The Solution

Combined both jobs into a single `release` job that uses the `changesets/action` as intended. The action intelligently handles both scenarios:

- **When changesets exist**: Runs `version` command → creates/updates release PR
- **When no changesets exist** (after release PR merge): Runs `publish` command → publishes to npm

This is the recommended pattern from the [changesets documentation](https://github.com/changesets/action).

## Changes Made

- Merged `version` and `publish` jobs into single `release` job
- Combined permissions from both jobs (contents, pull-requests, id-token)
- Added both `version` and `publish` parameters to the changesets action
- Kept the `npm-publish` environment for secure publishing

## Testing

The workflow will be tested when this PR is merged. Expected behavior:
1. ✅ CI runs on merge to main
2. ✅ Release workflow triggers
3. ✅ Single job runs that updates existing release PR #53
4. ✅ After PR #53 is merged, packages will publish to npm

## Related

- Fixes the issue discovered in workflow run: https://github.com/mike-north/api-extractor-tools/actions/runs/20010401165
- Follow-up to PR #50