### PR TITLE
feat: add automatic GitHub release creation on package publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          # Get the list of published packages
+          PUBLISHED_PACKAGES='${{ steps.changesets.outputs.publishedPackages }}'
+          
+          echo "Published packages:"
+          echo "${PUBLISHED_PACKAGES}" | jq -r '.[] | "- \(.name)@\(.version)"'
+          
+          # Use timestamp-based release tag for monorepo releases
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          RELEASE_TAG="release-${TIMESTAMP}"
+          RELEASE_NAME="Release ${TIMESTAMP}"
+          
+          # Build release notes
+          cat << 'EOF' > release_notes.md
+          ## Published Packages
+          
+          EOF
+          
+          echo "${PUBLISHED_PACKAGES}" | jq -r '.[] | "- [\(.name)](https://www.npmjs.com/package/\(.name)/v/\(.version)) - `\(.version)`"' >> release_notes.md
+          
+          cat << 'EOF' >> release_notes.md
+          
+          ## Installation
+          
+          Install any of the published packages:
+          
+          ```bash
+          EOF
+          
+          echo "${PUBLISHED_PACKAGES}" | jq -r '.[] | "npm install \(.name)@\(.version)"' >> release_notes.md
+          
+          cat << 'EOF' >> release_notes.md
+          ```
+          EOF
+          
+          # Create the GitHub release
+          gh release create "${RELEASE_TAG}" \
+            --title "${RELEASE_NAME}" \
+            --notes-file release_notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Automatically create a GitHub release whenever packages are successfully published to npm
- Includes formatted release notes with links to published packages on npm
- Provides installation instructions for all published packages

## Implementation Details

The release workflow now includes a new step that:
1. Checks if packages were published (using `steps.changesets.outputs.published`)
2. Generates release notes with all published package names, versions, and npm links
3. Creates a timestamped GitHub release (e.g., `release-20240107-123456`)
4. Attaches the formatted release notes

This makes it easier for users to track releases and discover what packages were published together in a monorepo context.

## Test plan

- [x] Verify the workflow YAML syntax is valid
- [ ] Test in production when next release is published