### PR TITLE
fix: improve GitHub release naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,23 @@ jobs:
             RELEASE_TAG="v${VERSION}"
             RELEASE_NAME="${PACKAGE_NAME} v${VERSION}"
           else
-            # Multiple packages: use readable date format
+            # Multiple packages: use readable date format with sequence number if needed
             RELEASE_DATE=$(date +%Y-%m-%d)
-            RELEASE_TAG="release-${RELEASE_DATE}"
-            RELEASE_NAME="Release ${RELEASE_DATE}"
+            BASE_TAG="release-${RELEASE_DATE}"
+            
+            # Check if tag exists and find the next available sequence number
+            SEQUENCE=0
+            RELEASE_TAG="${BASE_TAG}"
+            while git rev-parse "${RELEASE_TAG}" >/dev/null 2>&1; do
+              SEQUENCE=$((SEQUENCE + 1))
+              RELEASE_TAG="${BASE_TAG}-${SEQUENCE}"
+            done
+            
+            if [ "$SEQUENCE" -eq 0 ]; then
+              RELEASE_NAME="Release ${RELEASE_DATE}"
+            else
+              RELEASE_NAME="Release ${RELEASE_DATE} #${SEQUENCE}"
+            fi
           fi
           
           echo "Release tag: ${RELEASE_TAG}"


### PR DESCRIPTION
## Summary

Improves the GitHub release naming to be more user-friendly and handles edge cases:

- For single package releases, use the version as the tag (e.g., `v1.2.3`)
- For multiple package releases, use a readable date format (e.g., `Release 2024-12-08`)
- Handle multiple releases per day by appending sequence numbers (e.g., `Release 2024-12-08 #1`)

## Changes

1. **Better release naming**: Replaces timestamp format (`Release 20251208-002738`) with version-based tags for single packages or readable dates for multi-package releases
2. **Duplicate tag handling**: Checks if a release tag already exists and appends a sequence number to prevent conflicts

## Examples

**Single package release:**
- Tag: `v1.2.3`
- Name: `package-name v1.2.3`

**Multiple package release (first of the day):**
- Tag: `release-2024-12-08`
- Name: `Release 2024-12-08`

**Multiple package release (second of the day):**
- Tag: `release-2024-12-08-1`
- Name: `Release 2024-12-08 #1`

## Test plan

- [x] Verify the workflow YAML syntax is valid
- [ ] Test in production when next release is published