### PR TITLE
Fix detection of changes in nested namespace members (#1)

### DIFF
--- a/.changeset/fix-nested-namespace-detection.md
+++ b/.changeset/fix-nested-namespace-detection.md
@@ -1,0 +1,5 @@
+---
+'@api-extractor-tools/change-detector-core': patch
+---
+
+Fix detection of changes in nested namespace members. The `getNamespaceSignature` function now recursively processes nested namespaces to capture all member changes. Previously, adding/removing/modifying members in nested namespaces like `Outer.Inner.helper()` would go undetected.

--- a/tools/change-detector-core/test/edge-cases.test.ts
+++ b/tools/change-detector-core/test/edge-cases.test.ts
@@ -349,8 +349,7 @@ declare module "*.css" {
   })
 
   describe('module and namespace', () => {
-    // Known limitation: nested namespace member tracking not yet implemented
-    it.fails('handles internal namespaces', () => {
+    it('handles internal namespaces', () => {
       const report = compare(
         `export declare namespace Outer {
   namespace Inner {


### PR DESCRIPTION
## Summary

- Fix detection of changes in nested namespace members
- The `getNamespaceSignature` function now recursively processes nested namespaces to capture all member changes
- Previously, adding/removing/modifying members in nested namespaces like `Outer.Inner.helper()` would go undetected

Closes #1

## Changes

**File:** `tools/change-detector-core/src/parser-core.ts`

The `getNamespaceSignature` function now:
1. Checks if each export is a nested namespace (using `tsModule.isModuleDeclaration`)
2. Recursively calls itself for nested namespaces to capture their full member signatures
3. Uses normalized function signatures for function members within namespaces
4. Sorts members alphabetically for consistent ordering

## Test plan

- [x] All 425 existing tests pass
- [x] The previously failing test `handles internal namespaces` now passes
- [x] Changed test from `it.fails()` to `it()` in `edge-cases.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)