### PR TITLE
fix(change-detector-core): structural comparison for equivalent utility types

### DIFF
--- a/.changeset/fix-utility-type-structural-comparison.md
+++ b/.changeset/fix-utility-type-structural-comparison.md
@@ -1,0 +1,5 @@
+---
+'@api-extractor-tools/change-detector-core': patch
+---
+
+Fix structural comparison for equivalent utility types like `Pick` and `Omit`. The parser now correctly expands mapped types to their structural form when TypeScript can resolve them, enabling proper equality detection for structurally equivalent utility type expressions (e.g., `Pick<T, "a" | "b">` vs `Omit<T, "c">` when they produce the same result type).

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ temp/*
 # Editor logs
 .nvimlog
 ./scratch
+.claude

--- a/tools/change-detector-core/src/parser-core.ts
+++ b/tools/change-detector-core/src/parser-core.ts
@@ -630,16 +630,20 @@ function getSymbolSignature(
       return `${typeParamPrefix}${members.join(' & ')}`
     }
     // For object types with properties (but not literal types), expand to show structure
+    // This handles utility types like Pick, Omit, Partial, Required, etc.
+    // by resolving them to their structural form for accurate comparison
     if (
       type.getProperties().length > 0 &&
       !isLiteralType &&
       (type.flags & tsModule.TypeFlags.Object) !== 0
     ) {
-      // Only expand if it's a pure object type, not a primitive with methods
       const objectType = type as ts.ObjectType
+      // Expand anonymous types (inline object types) and mapped types (Pick, Omit, etc.)
+      // Mapped types have ObjectFlags.Mapped set
       if (
         objectType.objectFlags !== undefined &&
-        (objectType.objectFlags & tsModule.ObjectFlags.Anonymous) !== 0
+        ((objectType.objectFlags & tsModule.ObjectFlags.Anonymous) !== 0 ||
+          (objectType.objectFlags & tsModule.ObjectFlags.Mapped) !== 0)
       ) {
         return `${typeParamPrefix}${getStructuralSignature(type, checker, tsModule)}`
       }


### PR DESCRIPTION
## Summary

- Fix structural comparison for equivalent utility types like `Pick` and `Omit`
- When TypeScript can resolve utility types, the parser now correctly expands mapped types to their structural form
- Enables proper equality detection for structurally equivalent expressions (e.g., `Pick<T, "a" | "b">` vs `Omit<T, "c">` when they produce the same type)
- Added `ObjectFlags.Mapped` to the condition that triggers structural expansion of type aliases
- Test now includes minimal utility type definitions to ensure TypeScript can properly resolve the types

Fixes #3

## Test plan

- [x] Run `pnpm test` and verify all tests pass (425 tests)
- [x] Verify the Pick/Omit structural equivalence test case passes
- [x] Pre-commit hooks pass (lint, build, type-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)