### PR TITLE
feat(change-detector-core): add plugin validation utilities

### DIFF
--- a/.changeset/plugin-validation.md
+++ b/.changeset/plugin-validation.md
@@ -1,0 +1,20 @@
+---
+'@api-extractor-tools/change-detector-core': minor
+---
+
+Add plugin validation utilities for verifying plugin structure and metadata.
+
+New exports:
+
+- `validatePlugin()` - Validates a plugin conforms to the expected structure with detailed error reporting
+- `isValidPlugin()` - Type guard for checking if a value is a valid `ChangeDetectorPlugin`
+- `formatValidationErrors()` - Formats validation results into human-readable strings
+
+Validation covers:
+
+- Metadata validation (id format, name, semver version)
+- Capability validation (inputProcessors, policies, reporters, validators)
+- Factory function validation (createProcessor, createPolicy, etc.)
+- Duplicate ID detection within capability types
+- Extension format validation (must start with ".")
+- Reporter format validation (text, markdown, json, html, custom)

--- a/tools/change-detector-core/src/index.ts
+++ b/tools/change-detector-core/src/index.ts
@@ -147,6 +147,16 @@ export {
   adaptLegacyInputProcessorPlugin,
 } from './plugin-types'
 
+// Plugin validation exports
+export {
+  type PluginValidationError,
+  type PluginValidationResult,
+  type PluginValidationOptions,
+  validatePlugin,
+  isValidPlugin,
+  formatValidationErrors,
+} from './plugin-validation'
+
 /**
  * Compares two declaration strings and generates a comprehensive report.
  *

--- a/tools/change-detector-core/src/plugin-validation.ts
+++ b/tools/change-detector-core/src/plugin-validation.ts
@@ -1,0 +1,689 @@
+import type {
+  ChangeDetectorPlugin,
+  InputProcessorDefinition,
+  PolicyDefinition,
+  ReporterDefinition,
+  ValidatorDefinition,
+} from './plugin-types'
+
+// ============================================================================
+// Validation Result Types
+// ============================================================================
+
+/**
+ * A single validation error with location context.
+ *
+ * @alpha
+ */
+export interface PluginValidationError {
+  /**
+   * Dot-notation path to the invalid field.
+   *
+   * @example 'metadata.id', 'inputProcessors[0].extensions'
+   */
+  readonly path: string
+
+  /**
+   * Human-readable error message.
+   */
+  readonly message: string
+
+  /**
+   * Plugin ID if known (may not be available if metadata is invalid).
+   */
+  readonly pluginId?: string
+}
+
+/**
+ * Result of validating a plugin.
+ *
+ * @alpha
+ */
+export interface PluginValidationResult {
+  /**
+   * Whether the plugin passed all validation checks.
+   */
+  readonly valid: boolean
+
+  /**
+   * List of validation errors (empty if valid).
+   */
+  readonly errors: readonly PluginValidationError[]
+
+  /**
+   * List of validation warnings (non-fatal issues).
+   */
+  readonly warnings: readonly PluginValidationError[]
+}
+
+// ============================================================================
+// Validation Options
+// ============================================================================
+
+/**
+ * Options for plugin validation.
+ *
+ * @alpha
+ */
+export interface PluginValidationOptions {
+  /**
+   * Package name for error context (e.g., npm package name).
+   */
+  readonly packageName?: string
+
+  /**
+   * Whether to validate that factory functions are callable.
+   * Defaults to true.
+   */
+  readonly validateFactories?: boolean
+
+  /**
+   * Whether to allow plugins with no capabilities.
+   * Defaults to false (at least one capability required).
+   */
+  readonly allowEmptyCapabilities?: boolean
+}
+
+// ============================================================================
+// Validation Helpers
+// ============================================================================
+
+/**
+ * Validates that a value is a non-empty string.
+ */
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+/**
+ * Validates a plugin ID format.
+ * IDs should be lowercase with hyphens, similar to npm package names.
+ */
+function isValidPluginId(id: unknown): id is string {
+  if (!isNonEmptyString(id)) return false
+  // Allow lowercase letters, numbers, and hyphens
+  // Must start with a letter
+  return /^[a-z][a-z0-9-]*$/.test(id)
+}
+
+/**
+ * Validates a semantic version string.
+ */
+function isValidVersion(version: unknown): version is string {
+  if (!isNonEmptyString(version)) return false
+  // Basic semver check: major.minor.patch with optional prerelease
+  return /^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$/.test(version)
+}
+
+/**
+ * Validates a file extension (must start with dot).
+ */
+function isValidExtension(ext: unknown): ext is string {
+  if (!isNonEmptyString(ext)) return false
+  return ext.startsWith('.') && ext.length > 1
+}
+
+// ============================================================================
+// Capability Validators
+// ============================================================================
+
+/**
+ * Validates an input processor definition.
+ */
+function validateInputProcessor(
+  processor: unknown,
+  index: number,
+  pluginId: string | undefined,
+  options: PluginValidationOptions,
+): PluginValidationError[] {
+  const errors: PluginValidationError[] = []
+  const basePath = `inputProcessors[${index}]`
+
+  if (!processor || typeof processor !== 'object') {
+    errors.push({
+      path: basePath,
+      message: 'Input processor must be an object',
+      pluginId,
+    })
+    return errors
+  }
+
+  const p = processor as Record<string, unknown>
+
+  // Validate id
+  if (!isNonEmptyString(p.id)) {
+    errors.push({
+      path: `${basePath}.id`,
+      message: 'Input processor must have a non-empty id string',
+      pluginId,
+    })
+  }
+
+  // Validate name
+  if (!isNonEmptyString(p.name)) {
+    errors.push({
+      path: `${basePath}.name`,
+      message: 'Input processor must have a non-empty name string',
+      pluginId,
+    })
+  }
+
+  // Validate extensions
+  if (!Array.isArray(p.extensions) || p.extensions.length === 0) {
+    errors.push({
+      path: `${basePath}.extensions`,
+      message: 'Input processor must have at least one extension',
+      pluginId,
+    })
+  } else {
+    for (let i = 0; i < p.extensions.length; i++) {
+      if (!isValidExtension(p.extensions[i])) {
+        errors.push({
+          path: `${basePath}.extensions[${i}]`,
+          message: `Extension must be a non-empty string starting with "." (got ${JSON.stringify(p.extensions[i])})`,
+          pluginId,
+        })
+      }
+    }
+  }
+
+  // Validate createProcessor factory
+  if (options.validateFactories !== false) {
+    if (typeof p.createProcessor !== 'function') {
+      errors.push({
+        path: `${basePath}.createProcessor`,
+        message: 'Input processor must have a createProcessor function',
+        pluginId,
+      })
+    }
+  }
+
+  return errors
+}
+
+/**
+ * Validates a policy definition.
+ */
+function validatePolicy(
+  policy: unknown,
+  index: number,
+  pluginId: string | undefined,
+  options: PluginValidationOptions,
+): PluginValidationError[] {
+  const errors: PluginValidationError[] = []
+  const basePath = `policies[${index}]`
+
+  if (!policy || typeof policy !== 'object') {
+    errors.push({
+      path: basePath,
+      message: 'Policy must be an object',
+      pluginId,
+    })
+    return errors
+  }
+
+  const p = policy as Record<string, unknown>
+
+  // Validate id
+  if (!isNonEmptyString(p.id)) {
+    errors.push({
+      path: `${basePath}.id`,
+      message: 'Policy must have a non-empty id string',
+      pluginId,
+    })
+  }
+
+  // Validate name
+  if (!isNonEmptyString(p.name)) {
+    errors.push({
+      path: `${basePath}.name`,
+      message: 'Policy must have a non-empty name string',
+      pluginId,
+    })
+  }
+
+  // Validate createPolicy factory
+  if (options.validateFactories !== false) {
+    if (typeof p.createPolicy !== 'function') {
+      errors.push({
+        path: `${basePath}.createPolicy`,
+        message: 'Policy must have a createPolicy function',
+        pluginId,
+      })
+    }
+  }
+
+  return errors
+}
+
+/**
+ * Validates a reporter definition.
+ */
+function validateReporter(
+  reporter: unknown,
+  index: number,
+  pluginId: string | undefined,
+  options: PluginValidationOptions,
+): PluginValidationError[] {
+  const errors: PluginValidationError[] = []
+  const basePath = `reporters[${index}]`
+
+  if (!reporter || typeof reporter !== 'object') {
+    errors.push({
+      path: basePath,
+      message: 'Reporter must be an object',
+      pluginId,
+    })
+    return errors
+  }
+
+  const p = reporter as Record<string, unknown>
+
+  // Validate id
+  if (!isNonEmptyString(p.id)) {
+    errors.push({
+      path: `${basePath}.id`,
+      message: 'Reporter must have a non-empty id string',
+      pluginId,
+    })
+  }
+
+  // Validate name
+  if (!isNonEmptyString(p.name)) {
+    errors.push({
+      path: `${basePath}.name`,
+      message: 'Reporter must have a non-empty name string',
+      pluginId,
+    })
+  }
+
+  // Validate format
+  const validFormats = ['text', 'markdown', 'json', 'html', 'custom']
+  if (!isNonEmptyString(p.format) || !validFormats.includes(p.format)) {
+    errors.push({
+      path: `${basePath}.format`,
+      message: `Reporter must have a valid format (one of: ${validFormats.join(', ')})`,
+      pluginId,
+    })
+  }
+
+  // Validate createReporter factory
+  if (options.validateFactories !== false) {
+    if (typeof p.createReporter !== 'function') {
+      errors.push({
+        path: `${basePath}.createReporter`,
+        message: 'Reporter must have a createReporter function',
+        pluginId,
+      })
+    }
+  }
+
+  return errors
+}
+
+/**
+ * Validates a validator definition.
+ */
+function validateValidator(
+  validator: unknown,
+  index: number,
+  pluginId: string | undefined,
+  options: PluginValidationOptions,
+): PluginValidationError[] {
+  const errors: PluginValidationError[] = []
+  const basePath = `validators[${index}]`
+
+  if (!validator || typeof validator !== 'object') {
+    errors.push({
+      path: basePath,
+      message: 'Validator must be an object',
+      pluginId,
+    })
+    return errors
+  }
+
+  const p = validator as Record<string, unknown>
+
+  // Validate id
+  if (!isNonEmptyString(p.id)) {
+    errors.push({
+      path: `${basePath}.id`,
+      message: 'Validator must have a non-empty id string',
+      pluginId,
+    })
+  }
+
+  // Validate name
+  if (!isNonEmptyString(p.name)) {
+    errors.push({
+      path: `${basePath}.name`,
+      message: 'Validator must have a non-empty name string',
+      pluginId,
+    })
+  }
+
+  // Validate createValidator factory
+  if (options.validateFactories !== false) {
+    if (typeof p.createValidator !== 'function') {
+      errors.push({
+        path: `${basePath}.createValidator`,
+        message: 'Validator must have a createValidator function',
+        pluginId,
+      })
+    }
+  }
+
+  return errors
+}
+
+/**
+ * Checks for duplicate IDs within a capability array.
+ */
+function findDuplicateIds<T extends { id: string }>(
+  items: readonly T[],
+  capabilityType: string,
+  pluginId: string | undefined,
+): PluginValidationError[] {
+  const errors: PluginValidationError[] = []
+  const seen = new Map<string, number>()
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+    if (item && typeof item === 'object' && 'id' in item) {
+      const id = (item as { id: unknown }).id
+      if (typeof id === 'string') {
+        const firstIndex = seen.get(id)
+        if (firstIndex !== undefined) {
+          errors.push({
+            path: `${capabilityType}[${i}].id`,
+            message: `Duplicate ${capabilityType.slice(0, -1)} id "${id}" (first occurrence at index ${firstIndex})`,
+            pluginId,
+          })
+        } else {
+          seen.set(id, i)
+        }
+      }
+    }
+  }
+
+  return errors
+}
+
+// ============================================================================
+// Main Validation Function
+// ============================================================================
+
+/**
+ * Validates a plugin conforms to the expected structure.
+ *
+ * @remarks
+ * This function performs comprehensive validation including:
+ * - Metadata validation (id, name, version)
+ * - Capability validation (inputProcessors, policies, reporters, validators)
+ * - Unique ID checks within each capability type
+ * - Factory function validation (optional)
+ *
+ * @param plugin - The plugin to validate (can be any value)
+ * @param options - Validation options
+ * @returns Validation result with errors and warnings
+ *
+ * @example
+ * ```typescript
+ * import { validatePlugin } from '@api-extractor-tools/change-detector-core';
+ *
+ * const result = validatePlugin(myPlugin, { packageName: 'my-plugin' });
+ * if (!result.valid) {
+ *   console.error('Plugin validation failed:', result.errors);
+ * }
+ * ```
+ *
+ * @alpha
+ */
+export function validatePlugin(
+  plugin: unknown,
+  options: PluginValidationOptions = {},
+): PluginValidationResult {
+  const errors: PluginValidationError[] = []
+  const warnings: PluginValidationError[] = []
+  let pluginId: string | undefined
+
+  // Check if plugin is an object
+  if (!plugin || typeof plugin !== 'object') {
+    errors.push({
+      path: '',
+      message: `Plugin must be an object${options.packageName ? ` (from package "${options.packageName}")` : ''}`,
+    })
+    return { valid: false, errors, warnings }
+  }
+
+  const p = plugin as Record<string, unknown>
+
+  // =========================================================================
+  // Validate metadata
+  // =========================================================================
+
+  if (!p.metadata || typeof p.metadata !== 'object') {
+    errors.push({
+      path: 'metadata',
+      message: 'Plugin must have a metadata object',
+    })
+  } else {
+    const meta = p.metadata as Record<string, unknown>
+
+    // Validate id
+    if (!isValidPluginId(meta.id)) {
+      if (!isNonEmptyString(meta.id)) {
+        errors.push({
+          path: 'metadata.id',
+          message: 'Plugin metadata must have a non-empty id string',
+        })
+      } else {
+        errors.push({
+          path: 'metadata.id',
+          message: `Plugin id must be lowercase with hyphens (got "${meta.id}")`,
+        })
+      }
+    } else {
+      pluginId = meta.id
+    }
+
+    // Validate name
+    if (!isNonEmptyString(meta.name)) {
+      errors.push({
+        path: 'metadata.name',
+        message: 'Plugin metadata must have a non-empty name string',
+        pluginId,
+      })
+    }
+
+    // Validate version
+    if (!isValidVersion(meta.version)) {
+      if (!isNonEmptyString(meta.version)) {
+        errors.push({
+          path: 'metadata.version',
+          message: 'Plugin metadata must have a non-empty version string',
+          pluginId,
+        })
+      } else {
+        warnings.push({
+          path: 'metadata.version',
+          message: `Plugin version "${meta.version}" does not follow semver format`,
+          pluginId,
+        })
+      }
+    }
+
+    // Optional fields (just validate types if present)
+    if (
+      meta.description !== undefined &&
+      typeof meta.description !== 'string'
+    ) {
+      warnings.push({
+        path: 'metadata.description',
+        message: 'Plugin metadata description should be a string',
+        pluginId,
+      })
+    }
+
+    if (meta.homepage !== undefined && typeof meta.homepage !== 'string') {
+      warnings.push({
+        path: 'metadata.homepage',
+        message: 'Plugin metadata homepage should be a string',
+        pluginId,
+      })
+    }
+  }
+
+  // =========================================================================
+  // Validate capabilities
+  // =========================================================================
+
+  const inputProcessors = Array.isArray(p.inputProcessors)
+    ? p.inputProcessors
+    : []
+  const policies = Array.isArray(p.policies) ? p.policies : []
+  const reporters = Array.isArray(p.reporters) ? p.reporters : []
+  const validators = Array.isArray(p.validators) ? p.validators : []
+
+  const totalCapabilities =
+    inputProcessors.length +
+    policies.length +
+    reporters.length +
+    validators.length
+
+  // Check at least one capability exists (unless explicitly allowed)
+  if (!options.allowEmptyCapabilities && totalCapabilities === 0) {
+    errors.push({
+      path: '',
+      message:
+        'Plugin must provide at least one capability (inputProcessors, policies, reporters, or validators)',
+      pluginId,
+    })
+  }
+
+  // Validate input processors
+  for (let i = 0; i < inputProcessors.length; i++) {
+    errors.push(
+      ...validateInputProcessor(inputProcessors[i], i, pluginId, options),
+    )
+  }
+  errors.push(
+    ...findDuplicateIds(
+      inputProcessors as InputProcessorDefinition[],
+      'inputProcessors',
+      pluginId,
+    ),
+  )
+
+  // Validate policies
+  for (let i = 0; i < policies.length; i++) {
+    errors.push(...validatePolicy(policies[i], i, pluginId, options))
+  }
+  errors.push(
+    ...findDuplicateIds(policies as PolicyDefinition[], 'policies', pluginId),
+  )
+
+  // Validate reporters
+  for (let i = 0; i < reporters.length; i++) {
+    errors.push(...validateReporter(reporters[i], i, pluginId, options))
+  }
+  errors.push(
+    ...findDuplicateIds(
+      reporters as ReporterDefinition[],
+      'reporters',
+      pluginId,
+    ),
+  )
+
+  // Validate validators
+  for (let i = 0; i < validators.length; i++) {
+    errors.push(...validateValidator(validators[i], i, pluginId, options))
+  }
+  errors.push(
+    ...findDuplicateIds(
+      validators as ValidatorDefinition[],
+      'validators',
+      pluginId,
+    ),
+  )
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  }
+}
+
+/**
+ * Type guard to check if a value is a valid ChangeDetectorPlugin.
+ *
+ * @remarks
+ * This is a convenience function that combines validation with type narrowing.
+ * For detailed error information, use `validatePlugin()` directly.
+ *
+ * @param plugin - The value to check
+ * @returns True if the value is a valid plugin
+ *
+ * @example
+ * ```typescript
+ * if (isValidPlugin(loadedModule)) {
+ *   // loadedModule is typed as ChangeDetectorPlugin
+ *   registry.register(loadedModule);
+ * }
+ * ```
+ *
+ * @alpha
+ */
+export function isValidPlugin(plugin: unknown): plugin is ChangeDetectorPlugin {
+  return validatePlugin(plugin).valid
+}
+
+/**
+ * Formats validation errors into a human-readable string.
+ *
+ * @param result - The validation result
+ * @param packageName - Optional package name for context
+ * @returns Formatted error message
+ *
+ * @alpha
+ */
+export function formatValidationErrors(
+  result: PluginValidationResult,
+  packageName?: string,
+): string {
+  if (result.valid && result.warnings.length === 0) {
+    return 'Plugin is valid'
+  }
+
+  const lines: string[] = []
+
+  if (packageName) {
+    lines.push(
+      `Plugin validation ${result.valid ? 'passed with warnings' : 'failed'} for "${packageName}":`,
+    )
+  } else {
+    lines.push(
+      `Plugin validation ${result.valid ? 'passed with warnings' : 'failed'}:`,
+    )
+  }
+
+  if (result.errors.length > 0) {
+    lines.push('')
+    lines.push('Errors:')
+    for (const error of result.errors) {
+      const path = error.path ? ` at "${error.path}"` : ''
+      lines.push(`  - ${error.message}${path}`)
+    }
+  }
+
+  if (result.warnings.length > 0) {
+    lines.push('')
+    lines.push('Warnings:')
+    for (const warning of result.warnings) {
+      const path = warning.path ? ` at "${warning.path}"` : ''
+      lines.push(`  - ${warning.message}${path}`)
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/tools/change-detector-core/test/plugin-validation.test.ts
+++ b/tools/change-detector-core/test/plugin-validation.test.ts
@@ -1,0 +1,757 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validatePlugin,
+  isValidPlugin,
+  formatValidationErrors,
+  type PluginValidationResult,
+} from '../src/plugin-validation'
+import type { ChangeDetectorPlugin } from '../src/plugin-types'
+
+// Helper to create a minimal valid plugin
+function createValidPlugin(
+  overrides: Partial<ChangeDetectorPlugin> = {},
+): ChangeDetectorPlugin {
+  return {
+    metadata: {
+      id: 'test-plugin',
+      name: 'Test Plugin',
+      version: '1.0.0',
+    },
+    inputProcessors: [
+      {
+        id: 'default',
+        name: 'Default Processor',
+        extensions: ['.ts'],
+        createProcessor: () => ({
+          process: () => ({ symbols: new Map(), errors: [] }),
+        }),
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('validatePlugin', () => {
+  describe('basic validation', () => {
+    it('validates a correct plugin', () => {
+      const plugin = createValidPlugin()
+      const result = validatePlugin(plugin)
+
+      expect(result.valid).toBe(true)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('rejects null', () => {
+      const result = validatePlugin(null)
+
+      expect(result.valid).toBe(false)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0]!.message).toContain('must be an object')
+    })
+
+    it('rejects undefined', () => {
+      const result = validatePlugin(undefined)
+
+      expect(result.valid).toBe(false)
+      expect(result.errors).toHaveLength(1)
+    })
+
+    it('rejects non-objects', () => {
+      expect(validatePlugin('string').valid).toBe(false)
+      expect(validatePlugin(123).valid).toBe(false)
+      expect(validatePlugin(true).valid).toBe(false)
+      expect(validatePlugin([]).valid).toBe(false)
+    })
+
+    it('includes package name in error when provided', () => {
+      const result = validatePlugin(null, { packageName: 'my-package' })
+
+      expect(result.errors[0]!.message).toContain('my-package')
+    })
+  })
+
+  describe('metadata validation', () => {
+    it('requires metadata object', () => {
+      const result = validatePlugin({})
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.path === 'metadata')).toBe(true)
+    })
+
+    it('requires metadata.id', () => {
+      const result = validatePlugin({
+        metadata: { name: 'Test', version: '1.0.0' },
+        inputProcessors: [],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.path === 'metadata.id')).toBe(true)
+    })
+
+    it('requires metadata.name', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', version: '1.0.0' },
+        inputProcessors: [],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.path === 'metadata.name')).toBe(true)
+    })
+
+    it('requires metadata.version', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test' },
+        inputProcessors: [],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.path === 'metadata.version')).toBe(
+        true,
+      )
+    })
+
+    it('validates plugin id format (lowercase with hyphens)', () => {
+      // Valid IDs
+      expect(
+        validatePlugin(
+          createValidPlugin({
+            metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+          }),
+        ).valid,
+      ).toBe(true)
+      expect(
+        validatePlugin(
+          createValidPlugin({
+            metadata: { id: 'my-plugin', name: 'Test', version: '1.0.0' },
+          }),
+        ).valid,
+      ).toBe(true)
+      expect(
+        validatePlugin(
+          createValidPlugin({
+            metadata: { id: 'plugin123', name: 'Test', version: '1.0.0' },
+          }),
+        ).valid,
+      ).toBe(true)
+
+      // Invalid IDs
+      const invalidResult = validatePlugin(
+        createValidPlugin({
+          metadata: { id: 'MyPlugin', name: 'Test', version: '1.0.0' },
+        }),
+      )
+      expect(invalidResult.valid).toBe(false)
+      expect(invalidResult.errors.some((e) => e.path === 'metadata.id')).toBe(
+        true,
+      )
+
+      const numericStart = validatePlugin(
+        createValidPlugin({
+          metadata: { id: '123plugin', name: 'Test', version: '1.0.0' },
+        }),
+      )
+      expect(numericStart.valid).toBe(false)
+    })
+
+    it('warns on invalid semver version format', () => {
+      const result = validatePlugin(
+        createValidPlugin({
+          metadata: { id: 'test', name: 'Test', version: 'not-semver' },
+        }),
+      )
+
+      // Should still be valid (warning, not error)
+      expect(result.valid).toBe(true)
+      expect(result.warnings.some((w) => w.path === 'metadata.version')).toBe(
+        true,
+      )
+    })
+
+    it('accepts valid semver versions', () => {
+      const versions = [
+        '1.0.0',
+        '0.1.0',
+        '10.20.30',
+        '1.0.0-alpha',
+        '1.0.0-beta.1',
+        '1.0.0+build',
+      ]
+      for (const version of versions) {
+        const result = validatePlugin(
+          createValidPlugin({
+            metadata: { id: 'test', name: 'Test', version },
+          }),
+        )
+        expect(
+          result.warnings.filter((w) => w.path === 'metadata.version'),
+        ).toHaveLength(0)
+      }
+    })
+
+    it('warns on invalid optional field types', () => {
+      const result = validatePlugin({
+        ...createValidPlugin(),
+        metadata: {
+          id: 'test',
+          name: 'Test',
+          version: '1.0.0',
+          description: 123 as unknown as string,
+          homepage: true as unknown as string,
+        },
+      })
+
+      expect(result.valid).toBe(true)
+      expect(
+        result.warnings.some((w) => w.path === 'metadata.description'),
+      ).toBe(true)
+      expect(result.warnings.some((w) => w.path === 'metadata.homepage')).toBe(
+        true,
+      )
+    })
+  })
+
+  describe('capability validation', () => {
+    it('requires at least one capability by default', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+      })
+
+      expect(result.valid).toBe(false)
+      expect(
+        result.errors.some((e) =>
+          e.message.includes('at least one capability'),
+        ),
+      ).toBe(true)
+    })
+
+    it('allows empty capabilities when option is set', () => {
+      const result = validatePlugin(
+        {
+          metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        },
+        { allowEmptyCapabilities: true },
+      )
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('accepts plugins with only policies', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        policies: [
+          {
+            id: 'default',
+            name: 'Default Policy',
+            createPolicy: () => ({ name: 'default', classify: () => 'patch' }),
+          },
+        ],
+      })
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('accepts plugins with only reporters', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        reporters: [
+          {
+            id: 'default',
+            name: 'Default Reporter',
+            format: 'text',
+            createReporter: () => ({
+              format: () => ({ format: 'text' as const, content: '' }),
+            }),
+          },
+        ],
+      })
+
+      expect(result.valid).toBe(true)
+    })
+
+    it('accepts plugins with only validators', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        validators: [
+          {
+            id: 'default',
+            name: 'Default Validator',
+            createValidator: () => ({
+              validate: () => ({ valid: true, warnings: [], errors: [] }),
+            }),
+          },
+        ],
+      })
+
+      expect(result.valid).toBe(true)
+    })
+  })
+
+  describe('input processor validation', () => {
+    it('validates input processor id', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        inputProcessors: [
+          {
+            name: 'Test',
+            extensions: ['.ts'],
+            createProcessor: () => ({
+              process: () => ({ symbols: new Map(), errors: [] }),
+            }),
+          } as never,
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(
+        result.errors.some((e) => e.path === 'inputProcessors[0].id'),
+      ).toBe(true)
+    })
+
+    it('validates input processor name', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        inputProcessors: [
+          {
+            id: 'default',
+            extensions: ['.ts'],
+            createProcessor: () => ({
+              process: () => ({ symbols: new Map(), errors: [] }),
+            }),
+          } as never,
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(
+        result.errors.some((e) => e.path === 'inputProcessors[0].name'),
+      ).toBe(true)
+    })
+
+    it('validates extensions array is non-empty', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        inputProcessors: [
+          {
+            id: 'default',
+            name: 'Test',
+            extensions: [],
+            createProcessor: () => ({
+              process: () => ({ symbols: new Map(), errors: [] }),
+            }),
+          },
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(
+        result.errors.some((e) => e.path === 'inputProcessors[0].extensions'),
+      ).toBe(true)
+    })
+
+    it('validates extensions format (must start with dot)', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        inputProcessors: [
+          {
+            id: 'default',
+            name: 'Test',
+            extensions: ['ts', '.js'],
+            createProcessor: () => ({
+              process: () => ({ symbols: new Map(), errors: [] }),
+            }),
+          },
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(
+        result.errors.some(
+          (e) => e.path === 'inputProcessors[0].extensions[0]',
+        ),
+      ).toBe(true)
+    })
+
+    it('validates createProcessor is a function', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        inputProcessors: [
+          {
+            id: 'default',
+            name: 'Test',
+            extensions: ['.ts'],
+          } as never,
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(
+        result.errors.some(
+          (e) => e.path === 'inputProcessors[0].createProcessor',
+        ),
+      ).toBe(true)
+    })
+
+    it('skips factory validation when option is set', () => {
+      const result = validatePlugin(
+        {
+          metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+          inputProcessors: [
+            {
+              id: 'default',
+              name: 'Test',
+              extensions: ['.ts'],
+            } as never,
+          ],
+        },
+        { validateFactories: false },
+      )
+
+      expect(result.valid).toBe(true)
+    })
+  })
+
+  describe('policy validation', () => {
+    it('validates policy id', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        policies: [
+          {
+            name: 'Test',
+            createPolicy: () => ({ name: 'test', classify: () => 'patch' }),
+          } as never,
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.path === 'policies[0].id')).toBe(true)
+    })
+
+    it('validates policy name', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        policies: [
+          {
+            id: 'test',
+            createPolicy: () => ({ name: 'test', classify: () => 'patch' }),
+          } as never,
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.path === 'policies[0].name')).toBe(
+        true,
+      )
+    })
+
+    it('validates createPolicy is a function', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        policies: [{ id: 'test', name: 'Test' } as never],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(
+        result.errors.some((e) => e.path === 'policies[0].createPolicy'),
+      ).toBe(true)
+    })
+  })
+
+  describe('reporter validation', () => {
+    it('validates reporter id', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        reporters: [
+          {
+            name: 'Test',
+            format: 'text',
+            createReporter: () => ({
+              format: () => ({ format: 'text' as const, content: '' }),
+            }),
+          } as never,
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.path === 'reporters[0].id')).toBe(true)
+    })
+
+    it('validates reporter format', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        reporters: [
+          {
+            id: 'test',
+            name: 'Test',
+            format: 'invalid' as never,
+            createReporter: () => ({
+              format: () => ({ format: 'text' as const, content: '' }),
+            }),
+          },
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.path === 'reporters[0].format')).toBe(
+        true,
+      )
+    })
+
+    it('accepts valid reporter formats', () => {
+      const formats = ['text', 'markdown', 'json', 'html', 'custom'] as const
+      for (const format of formats) {
+        const result = validatePlugin({
+          metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+          reporters: [
+            {
+              id: 'test',
+              name: 'Test',
+              format,
+              createReporter: () => ({
+                format: () => ({ format: 'text' as const, content: '' }),
+              }),
+            },
+          ],
+        })
+        expect(result.valid).toBe(true)
+      }
+    })
+  })
+
+  describe('validator validation', () => {
+    it('validates validator id', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        validators: [
+          {
+            name: 'Test',
+            createValidator: () => ({
+              validate: () => ({ valid: true, warnings: [], errors: [] }),
+            }),
+          } as never,
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.path === 'validators[0].id')).toBe(
+        true,
+      )
+    })
+
+    it('validates createValidator is a function', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        validators: [{ id: 'test', name: 'Test' } as never],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(
+        result.errors.some((e) => e.path === 'validators[0].createValidator'),
+      ).toBe(true)
+    })
+  })
+
+  describe('duplicate ID detection', () => {
+    it('detects duplicate input processor IDs', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        inputProcessors: [
+          {
+            id: 'same-id',
+            name: 'First',
+            extensions: ['.ts'],
+            createProcessor: () => ({
+              process: () => ({ symbols: new Map(), errors: [] }),
+            }),
+          },
+          {
+            id: 'same-id',
+            name: 'Second',
+            extensions: ['.js'],
+            createProcessor: () => ({
+              process: () => ({ symbols: new Map(), errors: [] }),
+            }),
+          },
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.message.includes('Duplicate'))).toBe(
+        true,
+      )
+    })
+
+    it('detects duplicate policy IDs', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        policies: [
+          {
+            id: 'same-id',
+            name: 'First',
+            createPolicy: () => ({ name: 'a', classify: () => 'patch' }),
+          },
+          {
+            id: 'same-id',
+            name: 'Second',
+            createPolicy: () => ({ name: 'b', classify: () => 'patch' }),
+          },
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.message.includes('Duplicate'))).toBe(
+        true,
+      )
+    })
+
+    it('detects duplicate reporter IDs', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        reporters: [
+          {
+            id: 'same-id',
+            name: 'First',
+            format: 'text',
+            createReporter: () => ({
+              format: () => ({ format: 'text' as const, content: '' }),
+            }),
+          },
+          {
+            id: 'same-id',
+            name: 'Second',
+            format: 'markdown',
+            createReporter: () => ({
+              format: () => ({ format: 'markdown' as const, content: '' }),
+            }),
+          },
+        ],
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.errors.some((e) => e.message.includes('Duplicate'))).toBe(
+        true,
+      )
+    })
+
+    it('allows same ID across different capability types', () => {
+      const result = validatePlugin({
+        metadata: { id: 'test', name: 'Test', version: '1.0.0' },
+        inputProcessors: [
+          {
+            id: 'default',
+            name: 'Processor',
+            extensions: ['.ts'],
+            createProcessor: () => ({
+              process: () => ({ symbols: new Map(), errors: [] }),
+            }),
+          },
+        ],
+        policies: [
+          {
+            id: 'default',
+            name: 'Policy',
+            createPolicy: () => ({ name: 'p', classify: () => 'patch' }),
+          },
+        ],
+        reporters: [
+          {
+            id: 'default',
+            name: 'Reporter',
+            format: 'text',
+            createReporter: () => ({
+              format: () => ({ format: 'text' as const, content: '' }),
+            }),
+          },
+        ],
+      })
+
+      expect(result.valid).toBe(true)
+    })
+  })
+
+  describe('pluginId in errors', () => {
+    it('includes pluginId in errors when available', () => {
+      const result = validatePlugin({
+        metadata: { id: 'my-plugin', name: 'Test', version: '1.0.0' },
+        inputProcessors: [{ invalid: true } as never],
+      })
+
+      const errorWithPluginId = result.errors.find(
+        (e) => e.pluginId === 'my-plugin',
+      )
+      expect(errorWithPluginId).toBeDefined()
+    })
+  })
+})
+
+describe('isValidPlugin', () => {
+  it('returns true for valid plugins', () => {
+    const plugin = createValidPlugin()
+    expect(isValidPlugin(plugin)).toBe(true)
+  })
+
+  it('returns false for invalid plugins', () => {
+    expect(isValidPlugin(null)).toBe(false)
+    expect(isValidPlugin({})).toBe(false)
+    expect(isValidPlugin({ metadata: {} })).toBe(false)
+  })
+
+  it('acts as type guard', () => {
+    const maybePlugin: unknown = createValidPlugin()
+
+    if (isValidPlugin(maybePlugin)) {
+      // TypeScript should recognize this as ChangeDetectorPlugin
+      expect(maybePlugin.metadata.id).toBe('test-plugin')
+    } else {
+      throw new Error('Should be valid')
+    }
+  })
+})
+
+describe('formatValidationErrors', () => {
+  it('formats valid result', () => {
+    const result: PluginValidationResult = {
+      valid: true,
+      errors: [],
+      warnings: [],
+    }
+
+    expect(formatValidationErrors(result)).toBe('Plugin is valid')
+  })
+
+  it('formats errors with package name', () => {
+    const result: PluginValidationResult = {
+      valid: false,
+      errors: [{ path: 'metadata.id', message: 'Missing id' }],
+      warnings: [],
+    }
+
+    const formatted = formatValidationErrors(result, 'my-package')
+    expect(formatted).toContain('my-package')
+    expect(formatted).toContain('Missing id')
+    expect(formatted).toContain('metadata.id')
+  })
+
+  it('formats warnings', () => {
+    const result: PluginValidationResult = {
+      valid: true,
+      errors: [],
+      warnings: [{ path: 'metadata.version', message: 'Invalid semver' }],
+    }
+
+    const formatted = formatValidationErrors(result)
+    expect(formatted).toContain('passed with warnings')
+    expect(formatted).toContain('Invalid semver')
+  })
+
+  it('formats both errors and warnings', () => {
+    const result: PluginValidationResult = {
+      valid: false,
+      errors: [{ path: 'metadata.id', message: 'Missing id' }],
+      warnings: [{ path: 'metadata.version', message: 'Invalid semver' }],
+    }
+
+    const formatted = formatValidationErrors(result)
+    expect(formatted).toContain('Errors:')
+    expect(formatted).toContain('Warnings:')
+  })
+})


### PR DESCRIPTION
## Summary

Implements Issue #85: Plugin validation for verifying plugin structure and metadata before registration.

### New Exports

- `validatePlugin(plugin, options?)` - Comprehensive validation with detailed errors
- `isValidPlugin(plugin)` - Type guard for `ChangeDetectorPlugin`
- `formatValidationErrors(result, packageName?)` - Human-readable error formatting

### Validation Coverage

**Metadata Validation**
- `id` - Must be lowercase with hyphens (npm-style), e.g., `my-plugin`
- `name` - Required non-empty string
- `version` - Required; warns if not semver format
- `description` / `homepage` - Optional; warns if wrong type

**Capability Validation**
- At least one capability required (configurable via `allowEmptyCapabilities`)
- Input processors: `id`, `name`, `extensions` (must start with `.`), `createProcessor`
- Policies: `id`, `name`, `createPolicy`
- Reporters: `id`, `name`, `format` (text/markdown/json/html/custom), `createReporter`
- Validators: `id`, `name`, `createValidator`

**Additional Checks**
- Duplicate ID detection within each capability type
- Factory function validation (optional via `validateFactories`)
- Plugin ID included in error context when available

### Types

```typescript
interface PluginValidationResult {
  valid: boolean
  errors: readonly PluginValidationError[]
  warnings: readonly PluginValidationError[]
}

interface PluginValidationError {
  path: string      // e.g., 'metadata.id', 'inputProcessors[0].extensions'
  message: string
  pluginId?: string
}
```

## Test plan

- [x] 44 new unit tests covering all validation scenarios
- [x] All 469 tests pass (425 existing + 44 new)
- [x] Build succeeds for all packages

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)