### PR TITLE
docs: update plugin documentation for unified architecture

### DIFF
--- a/.changeset/plugin-docs-update.md
+++ b/.changeset/plugin-docs-update.md
@@ -1,0 +1,11 @@
+---
+'@api-extractor-tools/change-detector-core': patch
+---
+
+Update documentation for unified plugin architecture
+
+This updates all plugin documentation to reflect the new unified plugin architecture:
+
+- **PLUGIN_ARCHITECTURE.md**: Complete rewrite documenting the unified `ChangeDetectorPlugin` interface with all four capability types (input processors, policies, reporters, validators), plugin discovery keywords, registry usage, and ID resolution
+- **PLUGIN_DEVELOPMENT.md**: Complete rewrite with comprehensive examples for each capability type, multi-capability plugins, testing patterns, migration guide, and best practices
+- **README.md**: Added Plugin System section with overview of capabilities, usage examples, and links to detailed documentation

--- a/tools/change-detector-core/PLUGIN_ARCHITECTURE.md
+++ b/tools/change-detector-core/PLUGIN_ARCHITECTURE.md
@@ -1,80 +1,249 @@
-# Input Processor Plugin Architecture
+# Unified Plugin Architecture
 
-## Architectural Decision: Intermediate Representation
+The change-detector system uses a unified plugin architecture that allows plugins to provide any combination of capabilities: input processors, versioning policies, reporters, and validators.
 
-After evaluating multiple options for the intermediate representation used by input processor plugins, we have chosen **Option 4: Symbol map directly** - Processors produce `Map<string, ExportedSymbol>` per `tools/change-detector-core/src/types.ts`.
+## Plugin Structure
 
-### Options Evaluated
+Every plugin implements the `ChangeDetectorPlugin` interface:
 
-1. **TypeScript declaration strings** - Processors convert input → `.d.ts` strings → existing parser
-2. **TypeScript AST nodes** - Processors produce AST directly → bypass string parsing
-3. **Custom IR** - Define schema-agnostic intermediate representation
-4. **Symbol map directly** - Processors produce `Map<string, ExportedSymbol>` ✅ **SELECTED**
+```typescript
+interface ChangeDetectorPlugin {
+  // Required metadata
+  metadata: {
+    id: string // Unique identifier (e.g., 'typescript', 'graphql')
+    name: string // Human-readable name
+    version: string // Semantic version
+    description?: string
+    homepage?: string
+  }
 
-### Rationale
+  // Optional capability arrays
+  inputProcessors?: InputProcessorDefinition[]
+  policies?: PolicyDefinition[]
+  reporters?: ReporterDefinition[]
+  validators?: ValidatorDefinition[]
+}
+```
 
-The decision to use `Map<string, ExportedSymbol>` as the intermediate representation was based on the following criteria:
+## Capability Types
 
-#### Ease of Implementation for Plugin Authors
+### Input Processors
 
-- Plugin authors work with a simple, well-defined interface: `Map<string, ExportedSymbol>` where each `ExportedSymbol` contains just `name`, `kind`, and `signature`
-- No need to understand TypeScript AST internals or construct complex AST nodes
-- No need to generate valid TypeScript declaration syntax
-- Direct mapping from any format to symbols
+Input processors convert various file formats into the normalized `Map<string, ExportedSymbol>` representation used for change detection.
 
-#### Type Safety and Validation
+```typescript
+interface InputProcessorDefinition {
+  id: string // Capability ID within plugin
+  name: string // Human-readable name
+  extensions: string[] // File extensions (e.g., ['.ts', '.d.ts'])
+  mimeTypes?: string[] // MIME types for browser environments
+  description?: string
+  optionsSchema?: object // JSON Schema for options validation
+  createProcessor(options?): InputProcessor
+}
 
-- Strong TypeScript interfaces already exist and are well-tested
-- The `ExportedSymbol` interface provides clear contracts
-- `SymbolKind` enum constrains valid symbol types
-- Validation happens at the type level, not runtime parsing
+interface InputProcessor {
+  process(
+    content: string,
+    filename?: string,
+  ): ProcessResult | Promise<ProcessResult>
+}
 
-#### Isomorphic Compatibility (Browser + Node.js)
+interface ProcessResult {
+  symbols: Map<string, ExportedSymbol>
+  errors: string[]
+}
+```
 
-- `ExportedSymbol` is a pure data structure with no dependencies
-- No TypeScript compiler dependency required in plugins (unless needed for TS-specific processing)
-- Works identically in browser and Node.js environments
-- Serializable for network transport or storage
+### Versioning Policies
 
-#### Performance Implications
+Policies classify changes into semantic versioning impact levels (major, minor, patch, none).
 
-- Avoids double parsing: format → TypeScript string → symbols
-- Each processor can optimize for its specific format
-- No intermediate serialization/deserialization step
-- Direct construction of the target data structure
+```typescript
+interface PolicyDefinition {
+  id: string
+  name: string
+  description?: string
+  optionsSchema?: object
+  createPolicy(options?): VersioningPolicy | ExtendedVersioningPolicy
+}
 
-#### Flexibility for Diverse Formats
+interface VersioningPolicy {
+  name: string
+  classify(change: AnalyzedChange): ReleaseType
+}
 
-- **TypeScript**: Parse `.d.ts` and extract symbols
-- **GraphQL**: Map schema types, queries, mutations to symbols
-- **OpenAPI/Swagger**: Convert paths, operations, schemas to symbols
-- **Protocol Buffers**: Transform messages, services, enums to symbols
-- **Custom formats**: Any structured API definition can map to symbols
+// Extended policy with context support
+interface ExtendedVersioningPolicy extends VersioningPolicy {
+  classifyWithContext?(
+    change: AnalyzedChange,
+    context: PolicyContext,
+  ): ReleaseType
+}
+```
 
-### Symbol Mapping Guidelines
+### Reporters
 
-When implementing an input processor plugin, follow these guidelines for mapping your format to `ExportedSymbol`:
+Reporters format comparison reports for various output targets.
 
-#### SymbolKind Mapping
+```typescript
+interface ReporterDefinition {
+  id: string
+  name: string
+  format: 'text' | 'markdown' | 'json' | 'html' | 'custom'
+  fileExtension?: string // e.g., 'md', 'json'
+  description?: string
+  isAsync?: boolean
+  optionsSchema?: object
+  createReporter(options?): Reporter | AsyncReporter
+}
 
-- `function`: Functions, methods, operations, endpoints
-- `class`: Classes, objects with constructors
-- `interface`: Interfaces, schemas, message types
-- `type`: Type aliases, unions, custom types
-- `variable`: Constants, variables, parameters
-- `enum`: Enumerations, option sets
-- `namespace`: Modules, namespaces, packages
+interface Reporter {
+  format(report: ComparisonReport): ReportOutput
+  formatChange?(change: Change): ReportOutput
+  begin?(): ReportOutput | void
+  end?(): ReportOutput | void
+}
+```
 
-#### Signature Guidelines
+### Validators
 
-The `signature` field should be a human-readable, deterministic string that:
+Validators perform pre-comparison validation checks on parsed symbols.
 
-1. Uniquely identifies the symbol's structure
-2. Is consistent across equivalent definitions
-3. Includes all relevant type information
-4. Uses normalized formatting for comparison
+```typescript
+interface ValidatorDefinition {
+  id: string
+  name: string
+  description?: string
+  createValidator(options?): Validator
+}
 
-Example signatures:
+interface Validator {
+  validate(
+    symbols: Map<string, ExportedSymbol>,
+    source: string,
+  ): ValidationResult
+}
+
+interface ValidationResult {
+  valid: boolean
+  warnings: string[]
+  errors: string[]
+}
+```
+
+## Plugin Discovery
+
+Plugins are discovered via npm package.json keywords:
+
+| Keyword                                  | Description                    |
+| ---------------------------------------- | ------------------------------ |
+| `change-detector:plugin`                 | Unified plugins (preferred)    |
+| `change-detector:input-processor-plugin` | Legacy input processor plugins |
+
+### Package Requirements
+
+1. Include the appropriate keyword in `package.json`
+2. Depend on `@api-extractor-tools/change-detector-core`
+3. Default export the plugin object or factory function
+
+```json
+{
+  "name": "@api-extractor-tools/my-plugin",
+  "keywords": ["change-detector:plugin"],
+  "dependencies": {
+    "@api-extractor-tools/change-detector-core": "workspace:*"
+  }
+}
+```
+
+### Discovery Mechanism
+
+The discovery system:
+
+1. Scans `node_modules` for packages with plugin keywords
+2. Dynamically imports plugin modules
+3. Validates plugin structure
+4. Registers plugins with the plugin registry
+
+## Plugin Registry
+
+The registry provides centralized capability indexing and lookup:
+
+```typescript
+import { createPluginRegistry } from '@api-extractor-tools/change-detector-core'
+
+const registry = createPluginRegistry()
+
+// Register plugins
+registry.register(myPlugin)
+
+// Lookup by fully-qualified ID
+const processor = registry.getInputProcessor('typescript:default')
+const policy = registry.getPolicy('semver:strict')
+const reporter = registry.getReporter('github:pr-comment')
+
+// Shorthand lookup (when unambiguous)
+const processor = registry.getInputProcessor('typescript')
+
+// Find by extension or format
+const tsProcessors = registry.findInputProcessorsForExtension('.ts')
+const mdReporters = registry.findReportersForFormat('markdown')
+
+// List all capabilities
+const allProcessors = registry.listInputProcessors()
+const allPolicies = registry.listPolicies()
+```
+
+### ID Resolution
+
+Capabilities are identified by fully-qualified IDs: `{pluginId}:{capabilityId}`
+
+Examples:
+
+- `typescript:default` - The default processor from typescript plugin
+- `semver:strict` - The strict policy from semver plugin
+- `github:pr-comment` - The PR comment reporter from github plugin
+
+Shorthand IDs are supported when:
+
+- Plugin has only one capability of that type
+- Plugin has a capability with id `default`
+
+## Intermediate Representation
+
+All input processors produce a `Map<string, ExportedSymbol>` where each symbol contains:
+
+```typescript
+interface ExportedSymbol {
+  name: string // Symbol name
+  kind: SymbolKind // function, class, interface, type, variable, enum, namespace
+  signature: string // Type signature for comparison
+}
+```
+
+### Symbol Kind Mapping
+
+| SymbolKind  | Use For                                   |
+| ----------- | ----------------------------------------- |
+| `function`  | Functions, methods, operations, endpoints |
+| `class`     | Classes, objects with constructors        |
+| `interface` | Interfaces, schemas, message types        |
+| `type`      | Type aliases, unions, custom types        |
+| `variable`  | Constants, variables, parameters          |
+| `enum`      | Enumerations, option sets                 |
+| `namespace` | Modules, namespaces, packages             |
+
+### Signature Guidelines
+
+Signatures should be:
+
+1. **Human-readable**: Easy for developers to understand
+2. **Deterministic**: Same input produces same signature
+3. **Complete**: Include all relevant type information
+4. **Normalized**: Consistent formatting for comparison
+
+Examples:
 
 ```typescript
 // Function
@@ -90,86 +259,75 @@ Example signatures:
 'enum Status { Active = 0, Inactive = 1 }'
 ```
 
-## Plugin Discovery
+## Lifecycle Hooks
 
-Plugins are discovered via the `package.json` keyword `"change-detector:input-processor-plugin"` in `@api-extractor-tools/change-detector`.
-
-### Plugin Package Requirements
-
-1. **Keyword**: Must include `"change-detector:input-processor-plugin"` in `package.json` keywords array
-2. **Dependency**: Must depend on `@api-extractor-tools/change-detector-core` for type definitions
-3. **Export**: Must default export an object implementing `InputProcessorPlugin` interface
-4. **Isomorphic**: Should work in both Node.js and browser environments (unless specifically a Node.js-only plugin)
-
-### Discovery Mechanism
-
-The `@api-extractor-tools/change-detector` package:
-
-- Scans `node_modules` for packages with the plugin keyword
-- Dynamically imports plugin modules
-- Registers plugins for use by the change detector
-- Does not have explicit dependencies on plugins (plugins depend on core, detector discovers them)
-
-## Plugin Interface
-
-See `tools/change-detector-core/src/plugin-types.ts` for the complete interface definitions.
-
-### InputProcessor
-
-The `InputProcessor` interface represents a configured processor instance that can process input content:
+Plugins can implement lifecycle hooks for initialization and cleanup:
 
 ```typescript
-interface InputProcessor {
-  /** Process input content and return exported symbols */
-  process(
-    content: string,
-    filename?: string,
-  ): Promise<ProcessResult> | ProcessResult
+interface ChangeDetectorPluginWithLifecycle extends ChangeDetectorPlugin {
+  initialize?(): Promise<void> // Called when plugin is loaded
+  dispose?(): Promise<void> // Called when plugin is unloaded
 }
 ```
 
-### InputProcessorPlugin
+## Error Handling
 
-The `InputProcessorPlugin` interface represents a plugin that creates processor instances:
-
-```typescript
-interface InputProcessorPlugin {
-  /** Plugin identifier (e.g., 'typescript', 'graphql', 'openapi') */
-  id: string
-
-  /** Human-readable plugin name */
-  name: string
-
-  /** Plugin version */
-  version: string
-
-  /** File extensions this plugin handles (e.g., ['.d.ts', '.ts']) */
-  extensions: string[]
-
-  /** Create a processor instance with optional configuration */
-  createProcessor(options?: unknown): InputProcessor
-}
-```
-
-### ProcessResult
-
-The result of processing input:
+Plugins use structured errors with error codes:
 
 ```typescript
-interface ProcessResult {
-  /** Extracted exported symbols */
-  symbols: Map<string, ExportedSymbol>
-
-  /** Any errors encountered during processing */
-  errors: string[]
+class PluginError extends Error {
+  code: PluginErrorCode
+  pluginId?: string
+  capabilityId?: string
+  cause?: Error
 }
+
+type PluginErrorCode =
+  | 'PLUGIN_LOAD_FAILED'
+  | 'PLUGIN_INVALID_METADATA'
+  | 'PLUGIN_CAPABILITY_NOT_FOUND'
+  | 'PLUGIN_OPTIONS_INVALID'
+  | 'PROCESSOR_PARSE_ERROR'
+  | 'POLICY_CLASSIFICATION_ERROR'
+  | 'REPORTER_FORMAT_ERROR'
+  | 'VALIDATOR_ERROR'
 ```
 
-## Future Enhancements
+## Legacy Plugin Support
 
-The architecture supports these future capabilities (deferred to separate issues):
+Legacy `InputProcessorPlugin` plugins are automatically adapted to the unified format:
 
-- **Plugin Stacking/Pipeline**: Chain multiple processors together
-- **Transform Plugins**: Modify symbols before comparison
-- **Output Processors**: Custom formatters for reports
-- **Validation Plugins**: Additional validation rules
+```typescript
+import { adaptLegacyInputProcessorPlugin } from '@api-extractor-tools/change-detector-core'
+
+// Adapt legacy plugin to unified format
+const unifiedPlugin = adaptLegacyInputProcessorPlugin(legacyPlugin)
+registry.register(unifiedPlugin)
+```
+
+The adapter maps the legacy plugin to a unified plugin with:
+
+- `metadata` from legacy `id`, `name`, `version`
+- Single input processor with id `default`
+
+## Design Rationale
+
+### Why Symbol Map Directly?
+
+We chose `Map<string, ExportedSymbol>` as the intermediate representation because:
+
+1. **Easy for plugin authors**: Simple interface, no TypeScript AST knowledge needed
+2. **Type-safe**: Strong TypeScript interfaces with compile-time checking
+3. **Isomorphic**: Pure data structure works in Node.js and browser
+4. **Performant**: No intermediate serialization, direct construction
+5. **Flexible**: Any format can map to this representation
+
+### Why Unified Plugins?
+
+The unified plugin architecture provides:
+
+1. **Single registration**: One plugin provides multiple capabilities
+2. **Consistent patterns**: Same interface style across all capability types
+3. **Qualified IDs**: Clear capability identification with `pluginId:capabilityId`
+4. **Flexible discovery**: One keyword discovers all capabilities
+5. **Future-proof**: Easy to add new capability types

--- a/tools/change-detector-core/README.md
+++ b/tools/change-detector-core/README.md
@@ -130,6 +130,69 @@ import { compareDeclarations } from '@api-extractor-tools/change-detector-core'
 const report = compareDeclarations({ oldContent, newContent }, ts)
 ```
 
+## Plugin System
+
+The change-detector supports a unified plugin architecture for extending its capabilities:
+
+### Plugin Capabilities
+
+| Capability           | Description                                                   |
+| -------------------- | ------------------------------------------------------------- |
+| **Input Processors** | Convert different formats to symbols (GraphQL, OpenAPI, etc.) |
+| **Policies**         | Custom versioning rules for change classification             |
+| **Reporters**        | Custom output formats (PR comments, CI integration, etc.)     |
+| **Validators**       | Pre-comparison validation rules                               |
+
+### Using Plugins
+
+```typescript
+import { createPluginRegistry } from '@api-extractor-tools/change-detector-core'
+import graphqlPlugin from '@api-extractor-tools/input-processor-graphql'
+
+// Create registry and register plugins
+const registry = createPluginRegistry()
+registry.register(graphqlPlugin)
+
+// Look up capabilities
+const processor = registry.getInputProcessor('graphql:schema')
+const processors = registry.findInputProcessorsForExtension('.graphql')
+```
+
+### Creating Plugins
+
+Plugins implement the `ChangeDetectorPlugin` interface:
+
+```typescript
+import type { ChangeDetectorPlugin } from '@api-extractor-tools/change-detector-core'
+
+const myPlugin: ChangeDetectorPlugin = {
+  metadata: {
+    id: 'my-plugin',
+    name: 'My Plugin',
+    version: '1.0.0',
+  },
+  inputProcessors: [
+    /* ... */
+  ],
+  policies: [
+    /* ... */
+  ],
+  reporters: [
+    /* ... */
+  ],
+  validators: [
+    /* ... */
+  ],
+}
+
+export default myPlugin
+```
+
+For detailed documentation, see:
+
+- [Plugin Architecture](./PLUGIN_ARCHITECTURE.md) - Architecture overview
+- [Plugin Development Guide](./PLUGIN_DEVELOPMENT.md) - How to create plugins
+
 ## Relationship to `@api-extractor-tools/change-detector`
 
 - **`change-detector-core`** - Isomorphic core (this package), works everywhere


### PR DESCRIPTION
## Summary

This PR updates all plugin documentation to reflect the new unified plugin architecture implemented in issues #84-88.

### Changes

**PLUGIN_ARCHITECTURE.md** - Complete rewrite:
- Documents the `ChangeDetectorPlugin` interface with metadata and capability arrays
- Covers all four capability types (input processors, policies, reporters, validators)
- Explains plugin discovery keywords (`change-detector:plugin` vs legacy)
- Documents the plugin registry and fully-qualified ID system (`pluginId:capabilityId`)
- Includes shorthand ID resolution rules
- Documents lifecycle hooks and error handling

**PLUGIN_DEVELOPMENT.md** - Complete rewrite:
- Quick start guide for creating plugins
- Detailed examples for each capability type:
  - Input processor (GraphQL example)
  - Policy (lenient and context-aware examples)
  - Reporter (GitHub PR comment and CI JSON examples)
  - Validator (required exports and naming conventions)
- Multi-capability plugin example
- Testing patterns with validation utilities
- Migration guide from legacy `InputProcessorPlugin` format
- Best practices for error handling, signatures, and isomorphic design

**README.md** - New Plugin System section:
- Overview of capability types
- Usage examples with registry
- Links to detailed documentation

## Test plan

- [x] All 514 tests pass
- [x] Build succeeds
- [x] Markdown lint passes
- [ ] Review documentation for accuracy and clarity

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)