### PR TITLE
feat: migrate TypeScript input processor to unified plugin format

### DIFF
--- a/.changeset/typescript-plugin-unified.md
+++ b/.changeset/typescript-plugin-unified.md
@@ -1,0 +1,21 @@
+---
+'@api-extractor-tools/input-processor-typescript': minor
+'@api-extractor-tools/change-detector': minor
+---
+
+Migrate TypeScript input processor to unified plugin format
+
+**@api-extractor-tools/input-processor-typescript:**
+
+- Migrated from legacy `InputProcessorPlugin` to unified `ChangeDetectorPlugin` interface
+- Added `change-detector:plugin` keyword to package.json for plugin discovery
+- Kept `change-detector:input-processor-plugin` keyword for backward compatibility
+- Added `legacyPlugin` export for backward compatibility (deprecated)
+- Added comprehensive tests for unified plugin format including registry integration
+
+**@api-extractor-tools/change-detector:**
+
+- Added `@api-extractor-tools/input-processor-typescript` as a dependency for batteries-included TypeScript support
+- Re-exported `typescriptPlugin` for convenient access to the TypeScript input processor
+
+This completes the migration of the TypeScript input processor to the unified plugin architecture (Issue #88).

--- a/api-reports/change-detector.api.md
+++ b/api-reports/change-detector.api.md
@@ -32,6 +32,7 @@ import { ReleaseType } from '@api-extractor-tools/change-detector-core';
 import { ReorderingConfidence } from '@api-extractor-tools/change-detector-core';
 import { reportToJSON } from '@api-extractor-tools/change-detector-core';
 import { SymbolKind } from '@api-extractor-tools/change-detector-core';
+import { default as typescriptPlugin } from '@api-extractor-tools/input-processor-typescript';
 
 export { Change }
 
@@ -109,5 +110,7 @@ export { ReorderingConfidence }
 export { reportToJSON }
 
 export { SymbolKind }
+
+export { typescriptPlugin }
 
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 0.5.2
       '@changesets/cli':
         specifier: ^2.27.10
-        version: 2.29.8(@types/node@22.19.1)
+        version: 2.29.8(@types/node@24.10.2)
       '@commitlint/cli':
         specifier: ^20.2.0
-        version: 20.2.0(@types/node@22.19.1)(typescript@5.8.3)
+        version: 20.2.0(@types/node@24.10.2)(typescript@5.8.3)
       '@commitlint/config-conventional':
         specifier: ^20.2.0
         version: 20.2.0
@@ -25,10 +25,10 @@ importers:
         version: 9.39.1
       '@microsoft/api-documenter':
         specifier: ^7.28.2
-        version: 7.28.2(@types/node@22.19.1)
+        version: 7.28.2(@types/node@24.10.2)
       '@vitest/coverage-v8':
         specifier: ^4.0.15
-        version: 4.0.15(vitest@4.0.15(@types/node@22.19.1)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2))
+        version: 4.0.15(vitest@4.0.15(@types/node@24.10.2)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2))
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.6.1)
@@ -43,7 +43,7 @@ importers:
         version: 2.6.1
       knip:
         specifier: ^5.71.0
-        version: 5.71.0(@types/node@22.19.1)(typescript@5.8.3)
+        version: 5.71.0(@types/node@24.10.2)(typescript@5.8.3)
       lint-staged:
         specifier: ^15.5.2
         version: 15.5.2
@@ -64,13 +64,16 @@ importers:
         version: 8.48.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.3)
       vitest:
         specifier: ^4.0.15
-        version: 4.0.15(@types/node@22.19.1)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+        version: 4.0.15(@types/node@24.10.2)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
   tools/change-detector:
     dependencies:
       '@api-extractor-tools/change-detector-core':
         specifier: workspace:*
         version: link:../change-detector-core
+      '@api-extractor-tools/input-processor-typescript':
+        specifier: workspace:*
+        version: link:../input-processor-typescript
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -204,19 +207,19 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(yaml@2.8.2))
       '@vitest/coverage-v8':
         specifier: ^4.0.15
-        version: 4.0.15(vitest@4.0.15(@types/node@22.19.1)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2))
+        version: 4.0.15(vitest@4.0.15(@types/node@24.10.2)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2))
       jsdom:
         specifier: ^25.0.1
         version: 25.0.1
       vite:
         specifier: ^6.0.3
-        version: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.2)
+        version: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.15
-        version: 4.0.15(@types/node@22.19.1)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+        version: 4.0.15(@types/node@24.10.2)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
   tools/eslint-plugin:
     dependencies:
@@ -257,16 +260,22 @@ importers:
       '@api-extractor-tools/change-detector-core':
         specifier: workspace:*
         version: link:../change-detector-core
+      pkg-up:
+        specifier: ^5.0.0
+        version: 5.0.0
       typescript:
         specifier: 5.8.3
         version: 5.8.3
     devDependencies:
+      '@types/node':
+        specifier: ^24.10.2
+        version: 24.10.2
       '@vitest/coverage-v8':
         specifier: ^4.0.15
-        version: 4.0.15(vitest@4.0.15(@types/node@22.19.1)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2))
+        version: 4.0.15(vitest@4.0.15(@types/node@24.10.2)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2))
       vitest:
         specifier: ^4.0.15
-        version: 4.0.15(@types/node@22.19.1)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+        version: 4.0.15(@types/node@24.10.2)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
   tools/module-declaration-merger:
     dependencies:
@@ -1572,6 +1581,9 @@ packages:
   '@types/node@22.19.1':
     resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
 
+  '@types/node@24.10.2':
+    resolution: {integrity: sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -2546,6 +2558,10 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  find-up@6.3.0:
+    resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   find-up@7.0.0:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
@@ -3932,6 +3948,11 @@ packages:
   pkg-entry-points@1.1.1:
     resolution: {integrity: sha512-BhZa7iaPmB4b3vKIACoppyUoYn8/sFs17VJJtzrzPZvEnN2nqrgg911tdL65lA2m1ml6UI3iPeYbZQ4VXpn1mA==}
 
+  pkg-up@5.0.0:
+    resolution: {integrity: sha512-NbJJ+WABU/AKhl3ooFwMc3+dQi0StEYrFj1g+D7BlaE07pL98rBLP21XMfNyGlckzHOt4onU5OuLE1GNkQqVsA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    deprecated: Renamed to package-up
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4557,6 +4578,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
     engines: {node: '>=4'}
@@ -5048,7 +5072,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.29.8(@types/node@22.19.1)':
+  '@changesets/cli@2.29.8(@types/node@24.10.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
       '@changesets/assemble-release-plan': 6.0.9
@@ -5064,7 +5088,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@22.19.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.10.2)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -5173,11 +5197,11 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@commitlint/cli@20.2.0(@types/node@22.19.1)(typescript@5.8.3)':
+  '@commitlint/cli@20.2.0(@types/node@24.10.2)(typescript@5.8.3)':
     dependencies:
       '@commitlint/format': 20.2.0
       '@commitlint/lint': 20.2.0
-      '@commitlint/load': 20.2.0(@types/node@22.19.1)(typescript@5.8.3)
+      '@commitlint/load': 20.2.0(@types/node@24.10.2)(typescript@5.8.3)
       '@commitlint/read': 20.2.0
       '@commitlint/types': 20.2.0
       tinyexec: 1.0.2
@@ -5224,7 +5248,7 @@ snapshots:
       '@commitlint/rules': 20.2.0
       '@commitlint/types': 20.2.0
 
-  '@commitlint/load@20.2.0(@types/node@22.19.1)(typescript@5.8.3)':
+  '@commitlint/load@20.2.0(@types/node@24.10.2)(typescript@5.8.3)':
     dependencies:
       '@commitlint/config-validator': 20.2.0
       '@commitlint/execute-rule': 20.0.0
@@ -5232,7 +5256,7 @@ snapshots:
       '@commitlint/types': 20.2.0
       chalk: 5.6.2
       cosmiconfig: 9.0.0(typescript@5.8.3)
-      cosmiconfig-typescript-loader: 6.2.0(@types/node@22.19.1)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@24.10.2)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -5470,12 +5494,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/external-editor@1.0.3(@types/node@22.19.1)':
+  '@inquirer/external-editor@1.0.3(@types/node@24.10.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.0
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.10.2
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -5526,13 +5550,13 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@microsoft/api-documenter@7.28.2(@types/node@22.19.1)':
+  '@microsoft/api-documenter@7.28.2(@types/node@24.10.2)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.32.2(@types/node@22.19.1)
+      '@microsoft/api-extractor-model': 7.32.2(@types/node@24.10.2)
       '@microsoft/tsdoc': 0.16.0
-      '@rushstack/node-core-library': 5.19.1(@types/node@22.19.1)
-      '@rushstack/terminal': 0.19.5(@types/node@22.19.1)
-      '@rushstack/ts-command-line': 5.1.5(@types/node@22.19.1)
+      '@rushstack/node-core-library': 5.19.1(@types/node@24.10.2)
+      '@rushstack/terminal': 0.19.5(@types/node@24.10.2)
+      '@rushstack/ts-command-line': 5.1.5(@types/node@24.10.2)
       js-yaml: 4.1.1
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -5546,11 +5570,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor-model@7.32.2(@types/node@22.19.1)':
+  '@microsoft/api-extractor-model@7.32.2(@types/node@24.10.2)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.0
-      '@rushstack/node-core-library': 5.19.1(@types/node@22.19.1)
+      '@rushstack/node-core-library': 5.19.1(@types/node@24.10.2)
     transitivePeerDependencies:
       - '@types/node'
 
@@ -6131,7 +6155,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.1
 
-  '@rushstack/node-core-library@5.19.1(@types/node@22.19.1)':
+  '@rushstack/node-core-library@5.19.1(@types/node@24.10.2)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -6142,11 +6166,15 @@ snapshots:
       resolve: 1.22.11
       semver: 7.5.4
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.10.2
 
   '@rushstack/problem-matcher@0.1.1(@types/node@22.19.1)':
     optionalDependencies:
       '@types/node': 22.19.1
+
+  '@rushstack/problem-matcher@0.1.1(@types/node@24.10.2)':
+    optionalDependencies:
+      '@types/node': 24.10.2
 
   '@rushstack/rig-package@0.6.0':
     dependencies:
@@ -6161,13 +6189,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.1
 
-  '@rushstack/terminal@0.19.5(@types/node@22.19.1)':
+  '@rushstack/terminal@0.19.5(@types/node@24.10.2)':
     dependencies:
-      '@rushstack/node-core-library': 5.19.1(@types/node@22.19.1)
-      '@rushstack/problem-matcher': 0.1.1(@types/node@22.19.1)
+      '@rushstack/node-core-library': 5.19.1(@types/node@24.10.2)
+      '@rushstack/problem-matcher': 0.1.1(@types/node@24.10.2)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.10.2
 
   '@rushstack/ts-command-line@5.1.4(@types/node@22.19.1)':
     dependencies:
@@ -6178,9 +6206,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/ts-command-line@5.1.5(@types/node@22.19.1)':
+  '@rushstack/ts-command-line@5.1.5(@types/node@24.10.2)':
     dependencies:
-      '@rushstack/terminal': 0.19.5(@types/node@22.19.1)
+      '@rushstack/terminal': 0.19.5(@types/node@24.10.2)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -6375,6 +6403,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.10.2':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/prop-types@15.7.15': {}
@@ -6560,7 +6592,7 @@ snapshots:
       '@typescript-eslint/types': 8.48.1
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -6568,7 +6600,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@24.10.2)(jiti@2.6.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -6589,6 +6621,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.0.15(vitest@4.0.15(@types/node@24.10.2)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.15
+      ast-v8-to-istanbul: 0.3.8
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magicast: 0.5.1
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.15(@types/node@24.10.2)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@4.0.15':
     dependencies:
       '@standard-schema/spec': 1.0.0
@@ -6605,6 +6654,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.2.6(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.2)
+
+  '@vitest/mocker@4.0.15(vite@7.2.6(@types/node@24.10.2)(jiti@2.6.1)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.15
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.2.6(@types/node@24.10.2)(jiti@2.6.1)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.15':
     dependencies:
@@ -7040,9 +7097,9 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.2.0(@types/node@22.19.1)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
+  cosmiconfig-typescript-loader@6.2.0(@types/node@24.10.2)(cosmiconfig@9.0.0(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.10.2
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 2.6.1
       typescript: 5.8.3
@@ -7457,6 +7514,11 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  find-up@6.3.0:
+    dependencies:
+      locate-path: 7.2.0
+      path-exists: 5.0.0
 
   find-up@7.0.0:
     dependencies:
@@ -8019,10 +8081,10 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  knip@5.71.0(@types/node@22.19.1)(typescript@5.8.3):
+  knip@5.71.0(@types/node@24.10.2)(typescript@5.8.3):
     dependencies:
       '@nodelib/fs.walk': 1.2.8
-      '@types/node': 22.19.1
+      '@types/node': 24.10.2
       fast-glob: 3.3.3
       formatly: 0.3.0
       jiti: 2.6.1
@@ -8886,6 +8948,10 @@ snapshots:
 
   pkg-entry-points@1.1.1: {}
 
+  pkg-up@5.0.0:
+    dependencies:
+      find-up: 6.3.0
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -9497,6 +9563,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.16.0: {}
+
   unicode-emoji-modifier-base@1.0.0: {}
 
   unicorn-magic@0.1.0: {}
@@ -9540,7 +9608,7 @@ snapshots:
     dependencies:
       builtins: 5.1.0
 
-  vite@6.4.1(@types/node@22.19.1)(jiti@2.6.1)(yaml@2.8.2):
+  vite@6.4.1(@types/node@24.10.2)(jiti@2.6.1)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9549,7 +9617,7 @@ snapshots:
       rollup: 4.53.3
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.1
+      '@types/node': 24.10.2
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.2
@@ -9564,6 +9632,20 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.19.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      yaml: 2.8.2
+
+  vite@7.2.6(@types/node@24.10.2)(jiti@2.6.1)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.53.3
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.10.2
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.2
@@ -9592,6 +9674,44 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.1
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.15(@types/node@24.10.2)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.15
+      '@vitest/mocker': 4.0.15(vite@7.2.6(@types/node@24.10.2)(jiti@2.6.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.15
+      '@vitest/runner': 4.0.15
+      '@vitest/snapshot': 4.0.15
+      '@vitest/spy': 4.0.15
+      '@vitest/utils': 4.0.15
+      es-module-lexer: 1.7.0
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.2.6(@types/node@24.10.2)(jiti@2.6.1)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.2
       jsdom: 25.0.1
     transitivePeerDependencies:
       - jiti

--- a/tools/change-detector/package.json
+++ b/tools/change-detector/package.json
@@ -23,6 +23,7 @@
   "packageManager": "pnpm@10.24.0",
   "dependencies": {
     "@api-extractor-tools/change-detector-core": "workspace:*",
+    "@api-extractor-tools/input-processor-typescript": "workspace:*",
     "typescript": "5.8.3"
   },
   "devDependencies": {

--- a/tools/change-detector/src/index.ts
+++ b/tools/change-detector/src/index.ts
@@ -81,6 +81,9 @@ export {
 // Re-export core's string-based comparison function for convenience
 export { compareDeclarations as compareDeclarationStrings } from '@api-extractor-tools/change-detector-core'
 
+// Re-export the TypeScript input processor plugin for batteries-included usage
+export { default as typescriptPlugin } from '@api-extractor-tools/input-processor-typescript'
+
 // Main API
 import type { CompareOptions, ComparisonReport } from './types'
 import { parseDeclarationFileWithTypes } from './parser'

--- a/tools/input-processor-typescript/package.json
+++ b/tools/input-processor-typescript/package.json
@@ -20,6 +20,7 @@
     "api",
     "change-detection",
     "plugin",
+    "change-detector:plugin",
     "change-detector:input-processor-plugin"
   ],
   "author": "",
@@ -27,9 +28,11 @@
   "packageManager": "pnpm@10.24.0",
   "dependencies": {
     "@api-extractor-tools/change-detector-core": "workspace:*",
+    "pkg-up": "^5.0.0",
     "typescript": "5.8.3"
   },
   "devDependencies": {
+    "@types/node": "^24.10.2",
     "@vitest/coverage-v8": "^4.0.15",
     "vitest": "^4.0.15"
   },

--- a/tools/input-processor-typescript/test/tsconfig.json
+++ b/tools/input-processor-typescript/test/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2022", "DOM", "ESNext.Disposable"],
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   },
   "include": ["../src/**/*.ts", "**/*.ts"]
 }

--- a/tools/input-processor-typescript/tsconfig.cjs.json
+++ b/tools/input-processor-typescript/tsconfig.cjs.json
@@ -7,7 +7,8 @@
     "outDir": "./dist/cjs",
     "rootDir": "./src",
     "declaration": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "test"]

--- a/tools/input-processor-typescript/tsconfig.esm.json
+++ b/tools/input-processor-typescript/tsconfig.esm.json
@@ -7,7 +7,8 @@
     "outDir": "./dist/esm",
     "rootDir": "./src",
     "declaration": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "test"]

--- a/tools/input-processor-typescript/tsconfig.json
+++ b/tools/input-processor-typescript/tsconfig.json
@@ -5,7 +5,8 @@
     "rootDir": "src",
     "baseUrl": "src",
     "module": "CommonJS",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- Migrated `@api-extractor-tools/input-processor-typescript` from legacy `InputProcessorPlugin` to unified `ChangeDetectorPlugin` interface
- Added `change-detector:plugin` keyword to package.json for plugin discovery
- Kept `change-detector:input-processor-plugin` keyword for backward compatibility
- Added `legacyPlugin` export for backward compatibility (deprecated)
- Added comprehensive tests for unified plugin format including registry integration
- Added `@api-extractor-tools/input-processor-typescript` as a dependency of `@api-extractor-tools/change-detector` for batteries-included TypeScript support
- Re-exported `typescriptPlugin` from change-detector for convenient access

Closes #88

## Test plan

- [x] All existing tests pass
- [x] New unified plugin format tests pass
- [x] Plugin registry integration tests pass
- [x] Build succeeds for both packages
- [x] Legacy plugin export works for backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)