### PR TITLE
feat(eslint-plugin): support for enumType

### DIFF
--- a/tools/eslint-plugin/README.md
+++ b/tools/eslint-plugin/README.md
@@ -39,6 +39,7 @@ export default [
       '@api-extractor-tools/extra-release-tag': 'error',
       '@api-extractor-tools/public-on-private-member': 'error',
       '@api-extractor-tools/public-on-non-exported': 'error',
+      '@api-extractor-tools/valid-enum-type': 'warn',
     },
   },
 ]
@@ -67,6 +68,7 @@ module.exports = {
     '@api-extractor-tools/extra-release-tag': 'error',
     '@api-extractor-tools/public-on-private-member': 'error',
     '@api-extractor-tools/public-on-non-exported': 'error',
+    '@api-extractor-tools/valid-enum-type': 'warn',
   },
 }
 ```
@@ -373,6 +375,70 @@ export { myFunction }
 }
 ```
 
+### `@api-extractor-tools/valid-enum-type`
+
+Validates the usage of the `@enumType` TSDoc tag on enum declarations and string literal union type aliases.
+
+The `@enumType` tag specifies whether an enum is "open" (new members may be added) or "closed" (the set of members is fixed). This is used by the change detector to properly classify API changes.
+
+```ts
+// ❌ Bad - missing value
+/**
+ * @enumType
+ */
+export enum Status {
+  Active,
+  Inactive,
+}
+
+// ❌ Bad - invalid value
+/**
+ * @enumType invalid
+ */
+export enum Status {
+  Active,
+  Inactive,
+}
+
+// ❌ Bad - @enumType on invalid construct
+/**
+ * @enumType open
+ */
+export function myFunction(): void {}
+
+// ✅ Good - open enum
+/**
+ * Status values for a resource.
+ * @enumType open
+ * @public
+ */
+export enum Status {
+  Active = 'active',
+  Inactive = 'inactive',
+}
+
+// ✅ Good - closed string literal union
+/**
+ * Supported formats.
+ * @enumType closed
+ * @public
+ */
+export type Format = 'json' | 'xml'
+```
+
+**Options:**
+
+- `requireOnExported` (optional): When `true`, requires all exported enums and string literal unions to have an `@enumType` tag. Default: `false`
+
+```json
+{
+  "@api-extractor-tools/valid-enum-type": [
+    "warn",
+    { "requireOnExported": true }
+  ]
+}
+```
+
 ## Configuration Discovery
 
 Rules that read from `api-extractor.json` use the following strategy:
@@ -395,6 +461,7 @@ The `recommended` configuration enables all rules with these defaults:
 | `extra-release-tag`         | error    |
 | `public-on-private-member`  | error    |
 | `public-on-non-exported`    | error    |
+| `valid-enum-type`           | warn     |
 
 ## Requirements
 

--- a/tools/eslint-plugin/docs/rules/valid-enum-type.md
+++ b/tools/eslint-plugin/docs/rules/valid-enum-type.md
@@ -1,0 +1,153 @@
+# valid-enum-type
+
+Validates the usage of the `@enumType` TSDoc tag on enum declarations and string literal union type aliases.
+
+## Rule Details
+
+The `@enumType` tag is used to specify whether an enum or string literal union is "open" (new members may be added) or "closed" (the set of members is fixed). This information is used by the change detector to properly classify API changes.
+
+This rule ensures that:
+
+- `@enumType` tags have a valid value (`open` or `closed`)
+- `@enumType` tags are not duplicated
+- `@enumType` tags are only used on valid constructs (enums and string literal unions)
+- Optionally, exported enums and string literal unions have an `@enumType` tag
+
+## Options
+
+```json
+{
+  "@api-extractor-tools/valid-enum-type": [
+    "warn",
+    {
+      "requireOnExported": false
+    }
+  ]
+}
+```
+
+### `requireOnExported`
+
+Type: `boolean`
+Default: `false`
+
+When `true`, requires all exported enums and string literal union type aliases to have an `@enumType` tag.
+
+## Examples
+
+### ❌ Incorrect
+
+```ts
+// Missing value
+/**
+ * @enumType
+ */
+export enum Status {
+  Active,
+  Inactive,
+}
+
+// Invalid value
+/**
+ * @enumType invalid
+ */
+export enum Status {
+  Active,
+  Inactive,
+}
+
+// Multiple @enumType tags
+/**
+ * @enumType open
+ * @enumType closed
+ */
+export enum Status {
+  Active,
+  Inactive,
+}
+
+// @enumType on invalid construct
+/**
+ * @enumType open
+ */
+export function myFunction(): void {}
+
+// @enumType on non-string-literal union
+/**
+ * @enumType open
+ */
+export type NumberUnion = 1 | 2 | 3
+
+// With requireOnExported: true - missing @enumType
+export enum Status {
+  Active,
+  Inactive,
+}
+```
+
+### ✅ Correct
+
+```ts
+// Open enum - new members may be added in future versions
+/**
+ * Status values for a resource.
+ * @enumType open
+ * @public
+ */
+export enum Status {
+  Active = 'active',
+  Inactive = 'inactive',
+}
+
+// Closed enum - the set of members is fixed
+/**
+ * Boolean-like values.
+ * @enumType closed
+ * @public
+ */
+export enum YesNo {
+  Yes = 'yes',
+  No = 'no',
+}
+
+// String literal union with @enumType
+/**
+ * Supported color values.
+ * @enumType open
+ * @public
+ */
+export type Color = 'red' | 'green' | 'blue'
+
+// Single string literal (also valid)
+/**
+ * The only supported format.
+ * @enumType closed
+ * @public
+ */
+export type Format = 'json'
+
+// Without requireOnExported, missing @enumType is allowed
+export enum InternalStatus {
+  Pending,
+  Complete,
+}
+```
+
+## When to Use
+
+Use this rule when:
+
+- You use the `@enumType` tag to document enum semantics
+- You want to ensure consistent and valid `@enumType` usage
+- You want to require `@enumType` on all exported enums (with `requireOnExported: true`)
+
+## When Not to Use
+
+You might want to disable this rule if:
+
+- You don't use the `@enumType` tag in your codebase
+- You're not using the change detector that processes this tag
+
+## Related
+
+- [Open/Closed Enum Semantics](https://github.com/mike-north/api-extractor-tools/issues/127) - Epic describing the enum type feature

--- a/tools/eslint-plugin/src/configs/recommended.ts
+++ b/tools/eslint-plugin/src/configs/recommended.ts
@@ -24,6 +24,7 @@ export const recommendedRules: TSESLint.Linter.RulesRecord = {
   '@api-extractor-tools/extra-release-tag': 'error',
   '@api-extractor-tools/public-on-private-member': 'error',
   '@api-extractor-tools/public-on-non-exported': 'error',
+  '@api-extractor-tools/valid-enum-type': 'warn',
 }
 
 /**


### PR DESCRIPTION
# ESLint Plugin Integration for @enumType

## Summary

Completes the ESLint plugin integration for the `@enumType` TSDoc tag validation, adding the `valid-enum-type` rule to the recommended configuration and providing comprehensive documentation.

## Changes

### Recommended Configuration

- Added `valid-enum-type` rule to recommended config with `'warn'` severity
- Updated both flat config and legacy config examples in README

### Documentation

- Created `docs/rules/valid-enum-type.md` with:
  - Rule purpose and behavior explanation
  - Configuration options (`requireOnExported`)
  - Comprehensive examples of correct and incorrect usage
  - Guidance on when to use/not use the rule
- Updated `README.md` with:
  - Rule added to usage examples (flat and legacy configs)
  - Full rule documentation section
  - Rule added to recommended configuration table

## Test Plan

- [x] All 195 eslint-plugin tests pass
- [x] Build completes successfully
- [x] All lint checks pass (`pnpm check`)
- [x] API report is up to date

## Related Issues

Closes #135

Part of epic #127 (Open/Closed Enum Semantics)

## Dependencies

This PR depends on:
- #134 (ESLint Rule: valid-enum-type) - the rule implementation (already in this branch)

This PR completes the ESLint plugin work for the Open/Closed Enum Semantics epic.
