### PR TITLE
chore: exit alpha prerelease mode for 0.1.0 stable release

### DIFF
--- a/.changeset/bump-module-merger-to-stable.md
+++ b/.changeset/bump-module-merger-to-stable.md
@@ -1,0 +1,5 @@
+---
+'@api-extractor-tools/module-declaration-merger': minor
+---
+
+Bump to 0.1.0 for first stable release

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "@api-extractor-tools/change-detector": "0.0.1",


### PR DESCRIPTION
## Summary

- Exit changesets prerelease mode to enable stable versioning
- Add minor bump changeset for `module-declaration-merger` to reach 0.1.0

## What happens next

When this PR merges, the changesets GitHub action will:
1. Create a "Version Packages" PR that applies all 37 pending changesets
2. That PR will bump all packages to `0.1.0` and generate CHANGELOG entries
3. When merged, the release workflow will publish all packages to npm

## Verification

After release:
- [ ] `.changeset/pre.json` no longer exists
- [ ] All packages show version `0.1.0` in package.json
- [ ] CI passes on main branch
- [ ] Packages published to npm at 0.1.0