### PR TITLE
fix(eslint-plugin): resolve CJS-to-ESM interop double-default issue

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
+  "ignore": [".worktrees/**"],
   "workspaces": {
     ".": {
       "ignoreBinaries": ["changeset-change-detector"],

--- a/tools/eslint-plugin/src/index.ts
+++ b/tools/eslint-plugin/src/index.ts
@@ -115,3 +115,25 @@ export default plugin
 // Named exports for CommonJS compatibility
 export { rules }
 export { recommendedRules }
+
+// CJS→ESM interop: assign plugin properties directly onto module.exports so that
+// ESM consumers using Node's CJS interop see `plugin.configs` on the default import
+// rather than needing `plugin.default.configs` (the "double-default" problem).
+// When TypeScript compiles `export default plugin` it sets `exports.default = plugin`,
+// but ESM interop wraps the whole module.exports object as the namespace — meaning
+// `import p from '...'` gives `module.exports`, not `module.exports.default`.
+// Spreading the plugin shape onto module.exports fixes this for ESM consumers while
+// leaving named CJS consumers unaffected.
+//
+// We use Object.defineProperty to redefine properties because TypeScript's CJS emit
+// defines named exports with getter-only descriptors, making direct assignment throw.
+if (typeof module !== 'undefined') {
+  const exportsObj = module.exports as Record<string, unknown>
+  for (const key of ['meta', 'configs', 'rules'] as const) {
+    Object.defineProperty(exportsObj, key, {
+      enumerable: true,
+      configurable: true,
+      value: plugin[key],
+    })
+  }
+}

--- a/tools/eslint-plugin/src/index.ts
+++ b/tools/eslint-plugin/src/index.ts
@@ -116,14 +116,15 @@ export default plugin
 export { rules }
 export { recommendedRules }
 
-// CJS→ESM interop: assign plugin properties directly onto module.exports so that
-// ESM consumers using Node's CJS interop see `plugin.configs` on the default import
-// rather than needing `plugin.default.configs` (the "double-default" problem).
+// CJS→ESM interop: define the plugin's public `meta`, `configs`, and `rules`
+// properties directly on `module.exports` so that ESM consumers using Node's CJS
+// interop see `plugin.configs` on the default import rather than needing
+// `plugin.default.configs` (the "double-default" problem).
 // When TypeScript compiles `export default plugin` it sets `exports.default = plugin`,
 // but ESM interop wraps the whole module.exports object as the namespace — meaning
 // `import p from '...'` gives `module.exports`, not `module.exports.default`.
-// Spreading the plugin shape onto module.exports fixes this for ESM consumers while
-// leaving named CJS consumers unaffected.
+// Defining these plugin properties on `module.exports` fixes this for ESM consumers
+// while leaving named CJS consumers unaffected.
 //
 // We use Object.defineProperty to redefine properties because TypeScript's CJS emit
 // defines named exports with getter-only descriptors, making direct assignment throw.

--- a/tools/eslint-plugin/test/esm-interop.test.ts
+++ b/tools/eslint-plugin/test/esm-interop.test.ts
@@ -1,0 +1,106 @@
+/**
+ * CJS interop test: verifies that the built CJS output at dist/index.js
+ * exposes `configs`, `rules`, and `meta` directly on `module.exports` so
+ * that both CJS `require()` and ESM `import` consumers can access them
+ * without the "double-default" problem.
+ *
+ * Uses `require()` to get the raw `module.exports` object — this is also
+ * what Node's ESM interop wraps as the module namespace, so if properties
+ * are here, ESM `import plugin from '...'` will see them too.
+ *
+ * This test MUST import from the built artifact, not from source, because
+ * the bug only manifests in the compiled CJS output.
+ */
+
+import { createRequire } from 'node:module'
+import { describe, it, expect } from 'vitest'
+
+const require_ = createRequire(import.meta.url)
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- raw CJS exports object
+const moduleExports: Record<string, unknown> = require_('../dist/index.js')
+
+describe('CJS interop — built dist/index.js', () => {
+  describe('plugin properties on module.exports', () => {
+    it('has configs directly', () => {
+      expect(moduleExports).toHaveProperty('configs')
+    })
+
+    it('has rules directly', () => {
+      expect(moduleExports).toHaveProperty('rules')
+    })
+
+    it('has meta directly', () => {
+      expect(moduleExports).toHaveProperty('meta')
+    })
+
+    it('default.configs is the same object (no double-default indirection)', () => {
+      const defaultExport = moduleExports['default'] as
+        | Record<string, unknown>
+        | undefined
+      // module.exports.default exists (TypeScript sets it), but the plugin
+      // properties should be on module.exports directly, not only on .default
+      if (defaultExport !== undefined) {
+        expect(moduleExports['configs']).toBe(defaultExport['configs'])
+      }
+    })
+  })
+
+  describe('configs', () => {
+     
+    const configs = moduleExports['configs'] as Record<string, unknown>
+
+    it('configs.recommended exists', () => {
+      expect(configs['recommended']).toBeDefined()
+    })
+
+    it('configs.recommended has plugins', () => {
+      const recommended = configs['recommended'] as Record<string, unknown>
+      expect(recommended['plugins']).toBeDefined()
+    })
+
+    it('configs.recommended has rules', () => {
+      const recommended = configs['recommended'] as Record<string, unknown>
+      expect(recommended['rules']).toBeDefined()
+    })
+  })
+
+  describe('rules', () => {
+    const rules = moduleExports['rules'] as Record<string, unknown>
+
+    it('rules is an object', () => {
+      expect(typeof rules).toBe('object')
+      expect(rules).not.toBeNull()
+    })
+
+    const expectedRuleNames = [
+      'missing-release-tag',
+      'override-keyword',
+      'package-documentation',
+      'forgotten-export',
+      'incompatible-release-tags',
+      'extra-release-tag',
+      'public-on-private-member',
+      'public-on-non-exported',
+      'valid-enum-type',
+    ] as const
+
+    for (const ruleName of expectedRuleNames) {
+      it(`rules['${ruleName}'] exists`, () => {
+        expect(rules[ruleName]).toBeDefined()
+      })
+    }
+  })
+
+  describe('meta', () => {
+    const meta = moduleExports['meta'] as Record<string, unknown>
+
+    it('meta.name is the package name', () => {
+      expect(meta['name']).toBe('@api-extractor-tools/eslint-plugin')
+    })
+
+    it('meta.version is defined', () => {
+      expect(meta['version']).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes the CJS→ESM interop issue where `import plugin from '@api-extractor-tools/eslint-plugin'` results in a double-default (`plugin.default.configs` instead of `plugin.configs`)
- Excludes `.worktrees/` from knip analysis to prevent false positives

## Problem

The compiled CJS output sets `exports.default = plugin`, but TypeScript also emits getter-only descriptors for named exports (`rules`, `meta`, etc.). When Node's ESM loader imports this CJS module, `m.default` is the entire `module.exports` object — so `plugin.configs` is undefined and users must use the broken path `plugin.default.configs`.

This breaks the documented flat config usage:
```js
import apiExtractorPlugin from '@api-extractor-tools/eslint-plugin';
export default [apiExtractorPlugin.configs.recommended]; // TypeError!
```

## Fix

After `export default plugin`, a CJS interop block uses `Object.defineProperty` to redefine `meta`, `configs`, and `rules` directly on `module.exports`. This bypasses TypeScript's getter-only restriction and ensures ESM consumers get direct access to plugin properties on the default import.

## Test plan

- [ ] `pnpm build` succeeds
- [ ] Verified with `node -e "import(...).then(m => console.log(Object.keys(m.default.configs)))"` — shows `['recommended', 'recommended-legacy']` directly on `m.default`
- [ ] CJS `require(...)` still works: `require(...).default.configs.recommended` is accessible